### PR TITLE
fix spark dbt project path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     packages=find_packages(),
     package_data={
         'dbt': [
-            'include/dbt_spark/dbt_project.yml',
-            'include/dbt_spark/macros/*.sql',
+            'include/spark/dbt_project.yml',
+            'include/spark/macros/*.sql',
         ]
     },
     install_requires=[


### PR DESCRIPTION
Closes #8 by changing the `setup.py` package_data path to match the actual path of the Spark dbt project.