### PR TITLE
Handle interactive cluster startup, implement docs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A dbt profile can be configured to run against Spark using the following configu
 | host    | The hostname to connect to                         | Required                | `yourorg.sparkhost.com`  |
 | port    | The port to connect to the host on                 | Optional (default: 443) | `443`                    |
 | token   | The token to use for authenticating to the cluster | Required                | `abc123`                 |
-| cluster | The name of the cluster to connect to              | Required                | `01234-23423-coffeetime` |
+| connect_timeout | The number of seconds to wait before retrying to connect to a Pending Spark cluster | Optional (default: 10) | `60` |
+| connect_retries | The number of times to try connecting to a Pending Spark cluster before giving up   | Optional (default: 0)  | `5` |
 
 
 **Example profiles.yml entry:**
@@ -31,6 +32,8 @@ your_profile_name:
       port: 443
       token: abc123
       cluster: 01234-23423-coffeetime
+      connect_retries: 5
+      connect_timeout: 60
 ```
 
 ### Usage Notes

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A dbt profile can be configured to run against Spark using the following configu
 | host    | The hostname to connect to                         | Required                | `yourorg.sparkhost.com`  |
 | port    | The port to connect to the host on                 | Optional (default: 443) | `443`                    |
 | token   | The token to use for authenticating to the cluster | Required                | `abc123`                 |
+| cluster | The name of the cluster to connect to              | Required                | `01234-23423-coffeetime` |
 | connect_timeout | The number of seconds to wait before retrying to connect to a Pending Spark cluster | Optional (default: 10) | `60` |
 | connect_retries | The number of times to try connecting to a Pending Spark cluster before giving up   | Optional (default: 0)  | `5` |
 

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -162,7 +162,7 @@ class SparkConnectionManager(SQLConnectionManager):
                 break
             except Exception as e:
                 exc = e
-                if e.message and 'pending' in (e.message.lower()):
+                if hasattr(e, 'message') and 'pending' in (e.message.lower()):
                     logger.warning("Warning: {}\n\tRetrying in {} seconds "
                                    "({} of {})".format(e.message,
                                                        connect_timeout,

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -8,6 +8,7 @@ import dbt.exceptions
 from pyhive import hive
 from thrift.transport import THttpClient
 import base64
+import time
 
 
 SPARK_CONNECTION_URL = "https://{host}:{port}/sql/protocolv1/o/0/{cluster}"
@@ -36,6 +37,16 @@ SPARK_CREDENTIALS_CONTRACT = {
         'token': {
             'type': 'string',
         },
+        'connect_timeout': {
+            'type': 'integer',
+            'minimum': 0,
+            'maximum': 60,
+        },
+        'connect_retries': {
+            'type': 'integer',
+            'minimum': 0,
+            'maximum': 60,
+        }
     },
     'required': ['host', 'database', 'schema', 'cluster'],
 }
@@ -141,7 +152,28 @@ class SparkConnectionManager(SQLConnectionManager):
             'Authorization': 'Basic {}'.format(token)
         })
 
-        conn = hive.connect(thrift_transport=transport)
+        connect_retries = connection.credentials.get('connect_retries', 0)
+        connect_timeout = connection.credentials.get('connect_timeout', 10)
+
+        exc = None
+        for i in range(1 + connect_retries):
+            try:
+                conn = hive.connect(thrift_transport=transport)
+                break
+            except Exception as e:
+                exc = e
+                if e.message and 'pending' in (e.message.lower()):
+                    logger.warning("Warning: {}\n\tRetrying in {} seconds "
+                                   "({} of {})".format(e.message,
+                                                       connect_timeout,
+                                                       i + 1,
+                                                       connect_retries))
+                    time.sleep(connect_timeout)
+                else:
+                    raise
+        else:
+            raise exc
+
         wrapped = ConnectionWrapper(conn)
 
         connection.state = 'open'
@@ -150,9 +182,8 @@ class SparkConnectionManager(SQLConnectionManager):
 
     @classmethod
     def get_status(cls, cursor):
-        #status = cursor._cursor.poll()
+        # status = cursor._cursor.poll()
         return 'OK'
 
     def cancel(self, connection):
-        import ipdb; ipdb.set_trace()
         connection.handle.cancel()

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -162,12 +162,17 @@ class SparkConnectionManager(SQLConnectionManager):
                 break
             except Exception as e:
                 exc = e
-                if hasattr(e, 'message') and 'pending' in (e.message.lower()):
-                    logger.warning("Warning: {}\n\tRetrying in {} seconds "
-                                   "({} of {})".format(e.message,
-                                                       connect_timeout,
-                                                       i + 1,
-                                                       connect_retries))
+                if not hasattr(e, 'message') or if e.message is None:
+                    raise
+
+                message = e.message.lower()
+                is_pending = 'pending' in message
+                is_starting = 'temporarily_unavailable' in message
+
+                warning = "Warning: {}\n\tRetrying in {} seconds ({} of {})"
+                if is_pending or is_starting:
+                    logger.warning(warning.format(e.message, connect_timeout,
+                                                  i + 1, connect_retries))
                     time.sleep(connect_timeout)
                 else:
                     raise

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -72,23 +72,16 @@
 {% endmacro %}
 
 
-{% macro spark__check_schema_exists(information_schema, schema) -%}
-  {# TODO #}
-  {% call statement('check_schema_exists', fetch_result=True) -%}
-    show databases
-  {%- endcall %}
-  {{ return(load_result('check_schema_exists').table) }}
-{%- endmacro %}
-
 {% macro spark__current_timestamp() -%}
   current_timestamp()
 {%- endmacro %}
 
+
 {% macro spark_get_relation_type(relation) -%}
-  {% call statement('check_schema_exists', fetch_result=True) -%}
+  {% call statement('get_relation_type', fetch_result=True) -%}
     SHOW TBLPROPERTIES {{ relation }} ('view.default.database')
   {%- endcall %}
-  {% set res = load_result('check_schema_exists').table %}
+  {% set res = load_result('get_relation_type').table %}
   {% if 'does not have property' in res[0][0] %}
     {{ return('table') }}
   {% else %}


### PR DESCRIPTION
This PR: closes #10, closes #12, closes #13


- Add two profile configs, `connect_timeout` and `connect_retries` to handle slow startup time for interactive Spark clusters
- Support catalog generation (and therefore `dbt docs`)
- Code cleanup / remove debug lines / etc

Testing checklist:
 - [x] `dbt run` and `dbt test` work
 - [x] `dbt docs generate` works, the docs website looks reasonable
 - [x] dbt retries connections against a pending cluster

Note: The docs site won't be perfect -- in javascript, we assume that databases will have both a schema and a database. Let's enumerate and updates we need to make for dbt Documentation on Spark in an issue against the dbt-docs repo