### PR TITLE
Naïve table materialization

### DIFF
--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -1,19 +1,11 @@
 {% materialization table, adapter = 'spark' %}
   {%- set identifier = model['alias'] -%}
 
-  {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
-  {% if non_destructive_mode %}
-    {{ exceptions.raise_compiler_error("--non-destructive mode is not supported on Spark") }}
-  {% endif %}
-
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='table') -%}
-
-  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
-  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
 
   -- setup: if the target relation already exists, drop it
   {% if old_relation -%}

--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -1,0 +1,32 @@
+{% materialization table, adapter = 'spark' %}
+  {%- set identifier = model['alias'] -%}
+
+  {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
+  {% if non_destructive_mode %}
+    {{ exceptions.raise_compiler_error("--non-destructive mode is not supported on Spark") }}
+  {% endif %}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type='table') -%}
+
+  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
+  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
+
+  -- setup: if the target relation already exists, drop it
+  {% if old_relation -%}
+    {{ adapter.drop_relation(old_relation) }}
+  {%- endif %}
+
+  {{ run_hooks(pre_hooks) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ create_table_as(False, target_relation, sql) }}
+  {%- endcall %}
+
+  {{ run_hooks(post_hooks) }}
+
+{% endmaterialization %}

--- a/dbt/include/spark/macros/materializations/view.sql
+++ b/dbt/include/spark/macros/materializations/view.sql
@@ -1,4 +1,4 @@
-{% materialization table, adapter = 'spark' %}
+{% materialization view, adapter = 'spark' %}
   
   {%- set identifier = model['alias'] -%}
 
@@ -6,7 +6,7 @@
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
-                                                type='table') -%}
+                                                type='view') -%}
 
   {{ run_hooks(pre_hooks) }}
 
@@ -17,9 +17,9 @@
 
   -- build model
   {% call statement('main') -%}
-    {{ create_table_as(False, target_relation, sql) }}
+    {{ create_view_as(target_relation, sql) }}
   {%- endcall %}
 
   {{ run_hooks(post_hooks) }}
 
-{% endmaterialization %}
+{%- endmaterialization -%}


### PR DESCRIPTION
### Proposed change

Implement a _really_ simple table materialization for Spark that drops the existing table before creating.

From [Databricks docs](https://docs.databricks.com/spark/latest/spark-sql/language-manual/alter-table-or-view.html):
> For managed tables, renaming a table moves the table location; for unmanaged (external) tables, renaming a table does not move the table location.

In our experience, renaming the backup table takes as long as (or longer than) actual table creation. The [Databricks docs](https://docs.databricks.com/user-guide/tables.html#replace-table-contents) suggest two ways of replacing table contents: the simple way (this one) and the recommended way (using `insert overwrite`, which fails on schema changes).

### Questions

* We _could_ implement non-destructive mode using `insert overwrite`, since both the flag and the function assume that the table schema has not changed. It's analogous to Redshift's truncate + insert, though without the atomicity of a transaction. (But I believe that non-destructive mode is not long for this world?)
* The limitation above only exists for _managed_ Databricks tables (delta). A parquet table stored in a specified path always stores its data at that path, and the SparkSQL metadata can change without physically moving data. We've talked about wanting to implement custom paths as a table config option. IFF a table has a path and `file_format = 'parquet'`, we could then defer to the Redshift paradigm (create tmp + rename swap + drop old), since the names affect metadata only.