### PR TITLE
Try pyhive poll() to prevent cxn timeout

### DIFF
--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -103,7 +103,20 @@ class ConnectionWrapper(object):
         if sql.strip().endswith(";"):
             sql = sql.strip()[:-1]
 
-        return self._cursor.execute(sql, bindings)
+        poll = None
+        try:
+
+            self._cursor.execute(sql, bindings, async_=True)
+            while True:
+                #poll = self._cursor.fetchone()
+                poll = self._cursor.poll()
+                import time
+                time.sleep(self._cursor._poll_interval)
+                if poll.operationState == self._cursor._STATE_FINISHED:
+                    break
+        except Exception as e:
+            raise
+            pass
 
     @property
     def description(self):


### PR DESCRIPTION
Fixes #24 

@drewbanin and I spent some time today investigating the timeout issue where dbt would drop its connection to the thrift server at exactly 300 seconds, even as the query continues running in Spark.

We're still not sure where the 300s config is set, but `pyhive` offers a few methods for pinging a running query to check its status.

This PR implements [`poll()`](https://github.com/dropbox/PyHive/blob/master/pyhive/hive.py#L400), using the [default `_poll_interval` value](https://github.com/dropbox/PyHive/blob/master/pyhive/common.py#L29) of 1 s.

There is a higher-level function, [`pyhive.hive.fetchone()`](https://github.com/dropbox/PyHive/blob/master/pyhive/common.py#L94), that implements `poll()` as a means of returning the first row of a query result. I couldn't manage to get this working, receiving errors like `Expected state FINISHED, but found RUNNING`.

Crucially, this fix works:
```
dbt run -m my_big_table
Running with dbt=0.13.0
Found 25 models, 18 tests, 0 archives, 1 analyses, 211 macros, 0 operations, 1 seed files, 56 sources

13:39:15 | Concurrency: 1 threads (target='dev')
13:39:15 |
13:39:15 | 1 of 1 START table model jerco.my_big_table................. [RUN]
14:09:27 | 1 of 1 OK created table model jerco.my_big_table............ [OK in 1812.85s]
14:09:28 |
14:09:28 | Finished running 1 table models in 1816.60s.

Completed successfully

Done. PASS=1 ERROR=0 SKIP=0 TOTAL=1
```