### PR TITLE
Bump for 0.14.3

### DIFF
--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -50,7 +50,6 @@ class SparkAdapter(SQLAdapter):
         return self.execute_macro(
             GET_RELATION_TYPE_MACRO_NAME,
             kwargs=kwargs,
-            connection_name=model_name,
             release=True
         )
 
@@ -62,7 +61,6 @@ class SparkAdapter(SQLAdapter):
         results = self.execute_macro(
             LIST_RELATIONS_MACRO_NAME,
             kwargs=kwargs,
-            connection_name=model_name,
             release=True
         )
 
@@ -89,8 +87,7 @@ class SparkAdapter(SQLAdapter):
 
         self.execute_macro(
             DROP_RELATION_MACRO_NAME,
-            kwargs={'relation': relation},
-            connection_name=model_name
+            kwargs={'relation': relation}
         )
 
     def get_catalog(self, manifest):

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -16,7 +16,9 @@ class SparkRelation(BaseRelation):
             'database': False,
             'schema': True,
             'identifier': True,
-        }
+        },
+        'dbt_created': False,
+
     }
 
     SCHEMA = {
@@ -38,7 +40,8 @@ class SparkRelation(BaseRelation):
             'include_policy': BaseRelation.POLICY_SCHEMA,
             'quote_policy': BaseRelation.POLICY_SCHEMA,
             'quote_character': {'type': 'string'},
+            'dbt_created': {'type': 'boolean'},
         },
         'required': ['metadata', 'type', 'path', 'include_policy',
-                     'quote_policy', 'quote_character']
+                     'quote_policy', 'quote_character','dbt_created']
     }

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -43,5 +43,5 @@ class SparkRelation(BaseRelation):
             'dbt_created': {'type': 'boolean'},
         },
         'required': ['metadata', 'type', 'path', 'include_policy',
-                     'quote_policy', 'quote_character','dbt_created']
+                     'quote_policy', 'quote_character', 'dbt_created']
     }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt-spark"
-package_version = "0.13.0"
+package_version = "0.14.2"
 description = """The SparkSQL plugin for dbt (data build tool)"""
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt-spark"
-package_version = "0.14.2"
+package_version = "0.14.3"
 description = """The SparkSQL plugin for dbt (data build tool)"""
 
 setup(


### PR DESCRIPTION
- As per https://github.com/fishtown-analytics/dbt-spark/issues/23 adding `dbt_created` to Relations.

- Fixing issue `TypeError: execute_macro() got an unexpected keyword argument 'connection_name'` at `dbt/adapters/spark/impl.py", line 66, in list_relations_without_caching` after upgrading to dbt-0.14.2
 