### PR TITLE
Allow overriding hardcoded spark config in pre_hook

### DIFF
--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -20,8 +20,6 @@
     {%- set old_relation = none -%}
   {%- endif %}
 
-  {{ run_hooks(pre_hooks) }}
-
   {% call statement() %}
     set spark.sql.sources.partitionOverwriteMode = DYNAMIC
   {% endcall %}
@@ -30,6 +28,7 @@
     set spark.sql.hive.convertMetastoreParquet = false
   {% endcall %}
 
+  {{ run_hooks(pre_hooks) }}
 
   {#-- This is required to make dbt's incremental scheme work #}
   {%- if old_relation is none -%}


### PR DESCRIPTION
It would be nice to be able to override the default config set for incremental models:

`set spark.sql.hive.convertMetastoreParquet = false`

Currently, there is no way to do so. Running the prehooks after setting this configuration would allow to override it by doing the following:

```
{{ config(
    materialized='incremental',
    partition_by=['my_partition_key'],
    file_format='parquet',
    pre_hook=[
        'set spark.sql.hive.convertMetastoreParquet = true'
    ]
) }}
```

