### PR TITLE
Add support for extracting statistics

### DIFF
--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -180,6 +180,7 @@ class SparkAdapter(SQLAdapter):
             for relation in relations:
                 logger.debug("Getting table schema for relation {}", relation)
                 columns += [
-                    col.to_dict() for col in self.get_columns_in_relation(relation)
+                    col.to_dict() for col in
+                    self.get_columns_in_relation(relation)
                 ]
         return agate.Table.from_object(columns)

--- a/test/unit/test_macros.py
+++ b/test/unit/test_macros.py
@@ -1,9 +1,7 @@
 import mock
-import unittest
 import re
-from collections import defaultdict
+import unittest
 from jinja2 import Environment, FileSystemLoader
-from dbt.context.common import _add_validation
 
 
 class TestSparkMacros(unittest.TestCase):


### PR DESCRIPTION
Depends on https://github.com/fishtown-analytics/dbt-spark/pull/39

With Spark you can compute statistics using `ANALYZE TABLE <table> COMPUTE STATISTICS`. This will compute statistics such as number of rows, and size and this will be stored in the metastore. With this PR this data will be fetched and shown in the docs:

![image](https://user-images.githubusercontent.com/1134248/70537951-97c0e400-1b61-11ea-8a0b-c1dcd45a2d70.png)
