### PR TITLE
Leverage "show table extended" for Relation type metadata

### DIFF
--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -58,24 +58,29 @@ class SparkAdapter(SQLAdapter):
     def list_relations_without_caching(self, information_schema, schema,
                                        model_name=None):
         kwargs = {'information_schema': information_schema, 'schema': schema}
-        results = self.execute_macro(
-            LIST_RELATIONS_MACRO_NAME,
-            kwargs=kwargs,
-            release=True
-        )
+        try:
+            results = self.execute_macro(
+                LIST_RELATIONS_MACRO_NAME,
+                kwargs=kwargs,
+                release=True
+            )
+        except dbt.exceptions.RuntimeException as e:
+            if hasattr(e, 'msg') and f"Database '{schema}' not found" in e.msg:
+                return []
 
         relations = []
         quote_policy = {
             'schema': True,
             'identifier': True
         }
-        for _database, name, _ in results:
+        for _database, name, _, information in results:
+            rel_type = ('view' if 'Type: VIEW' in information else 'table')
             relations.append(self.Relation.create(
                 database=_database,
                 schema=_database,
                 identifier=name,
                 quote_policy=quote_policy,
-                type=None
+                type=rel_type
             ))
         return relations
 

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -57,7 +57,7 @@
 
 {% macro spark__list_relations_without_caching(information_schema, schema) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    show tables in {{ schema }}
+    show table extended in {{ schema }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching').table) %}

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -13,8 +13,7 @@
   {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,  type='table') -%}
 
   {%- set full_refresh = flags.FULL_REFRESH == True and old_relation is not none -%}
-  {%- set type = old_relation.type if old_relation.type is not none else spark_get_relation_type(this) -%}
-  {%- set old_relation_is_view = old_relation is not none and type == 'view' -%}
+  {%- set old_relation_is_view = old_relation is not none and old_relation.type == 'view' -%}
 
   {%- if full_refresh or old_relation_is_view -%}
     {{ adapter.drop_relation(old_relation) }}

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -13,7 +13,7 @@
   {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,  type='table') -%}
 
   {%- set full_refresh = flags.FULL_REFRESH == True and old_relation is not none -%}
-  {%- set type = spark_get_relation_type(this) if old_relation else none -%}
+  {%- set type = old_relation.type if old_relation.type is not none else spark_get_relation_type(this) -%}
   {%- set old_relation_is_view = old_relation is not none and type == 'view' -%}
 
   {%- if full_refresh or old_relation_is_view -%}


### PR DESCRIPTION
* Following #49, leverage `show table extended in ... like '*'` statement to get metadata on all relational objects in each database/schema, including their `Type`
* Naively check the `information` column result of the statement for the substring `'Type: VIEW'`. If found in the text result, set `relation.type` to `'view'`, otherwise set to `'table'`. (I am seeing `Type: MANAGED` for tables that dbt creates in Databricks.)
* Catch `Database ... not found` exception if dbt runs the statement for a database that doesn't (yet) exist. I encountered this error after creating a dbt model with a custom schema and executing a dbt commands which did not run that model (e.g. `dbt seed`).
* Fixes #48 