### PR TITLE
Return without results when list relations fails

### DIFF
--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -60,7 +60,8 @@ class SparkAdapter(SQLAdapter):
             if hasattr(e, 'msg') and f"Database '{schema}' not found" in e.msg:
                 return []
             else:
-                logger.debug(f"Error while retrieving information about {schema}: {e.msg}")
+                description = "Error while retrieving information about"
+                logger.debug(f"{description} {schema}: {e.msg}")
                 return []
 
         relations = []

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -59,6 +59,9 @@ class SparkAdapter(SQLAdapter):
         except dbt.exceptions.RuntimeException as e:
             if hasattr(e, 'msg') and f"Database '{schema}' not found" in e.msg:
                 return []
+            else:
+                logger.debug(f"Error while retrieving information about {schema}: {e.msg}")
+                return []
 
         relations = []
         quote_policy = {


### PR DESCRIPTION
Describing the schema can fail (e.g. I have a table with no `StorageDescriptor#InputFormat`) causing the describe command to fail. (The table is created via the Glue Crawler on AWS).

We might just return no results in this case to be able to continue generating docs.

The error when running dbt docs generate:


```
show table extended in raw like '*'
  
2020-02-13 18:27:57,861 (MainThread): Database Error
  org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: Unable to fetch table db_raw. StorageDescriptor#InputFormat cannot be null for table: db_raw (Service: null; Status Code: 0; Error Code: null; Request ID: null);
```

