### PR TITLE
Use dockerize from test image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   unit:
     docker:
-      - image: fishtownanalytics/test-container:5
+      - image: fishtownanalytics/test-container:6
         environment:
           DBT_INVOCATION_ENV: circle
     steps:
@@ -13,7 +13,7 @@ jobs:
   integration-spark2:
     docker:
 
-      - image: dmateusp/test-container:dockerize  # TODO: change me before merging
+      - image: fishtownanalytics/test-container:6
         environment:
           DBT_INVOCATION_ENV: circle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
           no_output_timeout: 1h
           environment:
               DBT_PROFILES_DIR: /home/dbt_test_user/project/test/integration/
-              SPARK_HOST: localhost
 
       - store_artifacts:
           path: ./logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
   integration-spark2:
     docker:
 
-      - image: fishtownanalytics/test-container:5
+      - image: dmateusp/test-container:dockerize  # TODO: change me before merging
         environment:
           DBT_INVOCATION_ENV: circle
 
@@ -38,13 +38,8 @@ jobs:
       - checkout
 
       - run:
-          name: install dockerize
-          command: curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.6.1
-      - run:
           name: Wait for Spark-Thrift
-          command: ./dockerize -wait tcp://localhost:10000 -timeout 15m -wait-retry-interval 5s
+          command: dockerize -wait tcp://localhost:10000 -timeout 15m -wait-retry-interval 5s
 
       - run:
           name: Checkout test project


### PR DESCRIPTION
I would like to add `dockerize` to the main test image to avoid having to download it on each trigger of integration tests

Also made a minor cleanup: removed the unused "SPARK_HOST" variable