### PR TITLE
upgrade to dbt-core==0.16.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,24 @@
+[bumpversion]
+current_version = 0.16.0a1
+parse = (?P<major>\d+)
+	\.(?P<minor>\d+)
+	\.(?P<patch>\d+)
+	((?P<prerelease>[a-z]+)(?P<num>\d+))?
+serialize = 
+	{major}.{minor}.{patch}{prerelease}{num}
+	{major}.{minor}.{patch}
+commit = False
+tag = False
+
+[bumpversion:part:prerelease]
+first_value = a
+values = 
+	a
+	b
+	rc
+
+[bumpversion:part:num]
+first_value = 1
+
+[bumpversion:file:setup.py]
+

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -119,7 +119,6 @@ class SparkAdapter(SQLAdapter):
                 identifier=name,
                 type=rel_type
             )
-            self.cache_added(relation)
             relations.append(relation)
 
         return relations

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -81,6 +81,9 @@ class SparkAdapter(SQLAdapter):
     def convert_datetime_type(cls, agate_table, col_idx):
         return "timestamp"
 
+    def quote(self, identifier):
+        return '`{}`'.format(identifier)
+
     def add_schema_to_cache(self, schema) -> str:
         """Cache a new schema in dbt. It will show up in `list relations`."""
         if schema is None:

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -134,18 +134,6 @@
   current_timestamp()
 {%- endmacro %}
 
-{% macro spark__create_schema(database_name, schema_name) -%}
-  {%- call statement('create_schema') -%}
-    create schema if not exists {{ schema_name }}
-  {%- endcall -%}
-{% endmacro %}
-
-{% macro spark__drop_schema(database_name, schema_name) -%}
-  {%- call statement('drop_schema') -%}
-    drop schema if exists {{ schema_name }} cascade
-  {%- endcall -%}
-{% endmacro %}
-
 {% macro spark__rename_relation(from_relation, to_relation) -%}
   {% call statement('rename_relation') -%}
     {% if not from_relation.type %}

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -61,7 +61,7 @@
 {% endmacro %}
 
 
-{% macro spark__get_merge_sql(target, source, unique_key, dest_columns, predicates=[]) %}
+{% macro spark__get_merge_sql(target, source, unique_key, dest_columns, predicates=none) %}
   {# ignore dest_columns - we will just use `*` #}
     merge into {{ target }} as DBT_INTERNAL_DEST
       using {{ source.include(schema=false) }} as DBT_INTERNAL_SOURCE

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,20 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt-spark"
-package_version = "0.15.3"
+package_version = "0.16.0a1"
 description = """The SparkSQL plugin for dbt (data build tool)"""
+
+# evade bumpversion with this fun trick
+DBT_VERSION = (0, 16, 0)
+dbt_version = '.'.join(map(str, DBT_VERSION))
+# the package version should be the dbt version, with maybe some things on the
+# ends of it. (0.16.0 vs 0.16.0a1, 0.16.0.1, ...)
+if not package_version.startswith(dbt_version):
+    raise ValueError(
+        f'Invalid setup.py: package_version={package_version} must start with '
+        f'dbt_version={dbt_version} (from {DBT_VERSION})'
+    )
+
 
 setup(
     name=package_name,
@@ -33,8 +45,7 @@ setup(
         ]
     },
     install_requires=[
-        f'dbt-core>=={package_version}',
-        'jinja2<3.0.0',  # until dbt-core reaches 0.16.0: https://github.com/fishtown-analytics/dbt/issues/2147
+        f'dbt-core=={dbt_version}',
         'PyHive[hive]>=0.6.0,<0.7.0',
         'thrift>=0.11.0,<0.12.0',
     ]


### PR DESCRIPTION
Fixes #67 

Upgrade `dbt-spark` to work with `dbt-core==0.16.0`

- remove duplicate macros (as of `dbt-core==0.16.0`, this is an error)
- use `get_merge_sql` from `dbt-core` instead of a custom one
- slightly loosen versioning restrictions between `dbt-core` and `dbt-spark`
- Fix the requirements to use `==` instead of `>==` (which becomes `>=`!)
- add bumpversion