### PR TITLE
Table formatting of Usage Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ The following configurations can be supplied to models run with the dbt-spark pl
 
 
 | Option  | Description                                        | Required?               | Example                  |
-| file_format | The file format to use when creating tables (`parquet`, `delta`, `csv`, `json`, `text`, `jdbc`, `orc`, `hive` or `libsvm`). | Optional | `parquet` |
+|---------|----------------------------------------------------|-------------------------|--------------------------|
+| file_format | The file format to use when creating tables (`parquet`, `delta`, `csv`, `json`, `text`, `jdbc`, `orc`, `hive` or `libsvm`). | Optional | `parquet`|
 | location_root  | The created table uses the specified directory to store its data. The table alias is appended to it. | Optional                | `/mnt/root`              |
 | partition_by  | Partition the created table by the specified columns. A directory is created for each partition. | Optional                | `partition_1`              |
 | clustered_by  | Each partition in the created table will be split into a fixed number of buckets by the specified columns. | Optional               | `cluster_1`              |


### PR DESCRIPTION
Tiny fix to formatting in Readme.md for the Usage Notes table. Barely seemed worth it so feel free to ignore, but I fixed it in my fork so that I could read the table and figured I might as well offer up the PR.