### PR TITLE
Upgrade to 0.17.0rc2

### DIFF
--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.0rc1
+current_version = 0.17.0rc2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 0.16.1
+current_version = 0.17.0rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	((?P<prerelease>[a-z]+)(?P<num>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prerelease}{num}
 	{major}.{minor}.{patch}
 commit = False
@@ -12,7 +12,7 @@ tag = False
 
 [bumpversion:part:prerelease]
 first_value = a
-values =
+values = 
 	a
 	b
 	rc
@@ -23,3 +23,4 @@ first_value = 1
 [bumpversion:file:setup.py]
 
 [bumpversion:file:requirements.txt]
+

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.1
+current_version = 0.17.0rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.0rc1
+current_version = 0.17.0rc2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "0.17.0rc1"
+version = "0.17.0rc2"

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "0.16.1"
+version = "0.17.0rc1"

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -48,8 +48,10 @@ class SparkCredentials(Credentials):
             self.database != self.schema
         ):
             raise dbt.exceptions.RuntimeException(
-                f'In credentials: got database={self.database} but '
-                f'schema={self.schema} - on spark, both most be the same value'
+                f'    schema: {self.schema} \n'
+                f'    database: {self.database} \n'
+                f'On Spark, database must be omitted or have the same value as'
+                f' schema.'
             )
         self.database = self.schema
 

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -32,10 +32,10 @@ class SparkCredentials(Credentials):
     host: str
     method: SparkConnectionMethod
     schema: str
-    cluster: Optional[str]
-    token: Optional[str]
-    user: Optional[str]
     database: Optional[str]
+    cluster: Optional[str] = None
+    token: Optional[str] = None
+    user: Optional[str] = None
     port: int = 443
     organization: str = '0'
     connect_retries: int = 0
@@ -43,6 +43,14 @@ class SparkCredentials(Credentials):
 
     def __post_init__(self):
         # spark classifies database and schema as the same thing
+        if (
+            self.database is not None and
+            self.database != self.schema
+        ):
+            raise dbt.exceptions.RuntimeException(
+                f'In credentials: got database={self.database} but '
+                f'schema={self.schema} - on spark, both most be the same value'
+            )
         self.database = self.schema
 
     @property

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -28,9 +28,12 @@ class SparkRelation(BaseRelation):
         # some core things set database='', which we should ignore.
         if self.database and self.database != self.schema:
             raise RuntimeException(
-                f'In relation with identifier={self.identifier}, '
-                f'schema={self.schema}: got database={self.database}, but it '
-                f'should not be set'
+                f'Error while parsing relation {self.name}: \n'
+                f'    identifier: {self.identifier} \n'
+                f'    schema: {self.schema} \n'
+                f'    database: {self.database} \n'
+                f'On Spark, database should not be set. Use the schema '
+                f'config to set a custom schema/database for this relation.'
             )
 
     def render(self):

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from dbt.adapters.base.relation import BaseRelation, Policy
+from dbt.exceptions import RuntimeException
 
 
 @dataclass
@@ -22,3 +23,20 @@ class SparkRelation(BaseRelation):
     quote_policy: SparkQuotePolicy = SparkQuotePolicy()
     include_policy: SparkIncludePolicy = SparkIncludePolicy()
     quote_character: str = '`'
+
+    def __post_init__(self):
+        # some core things set database='', which we should ignore.
+        if self.database and self.database != self.schema:
+            raise RuntimeException(
+                f'In relation with identifier={self.identifier}, '
+                f'schema={self.schema}: got database={self.database}, but it '
+                f'should not be set'
+            )
+
+    def render(self):
+        if self.include_policy.database and self.include_policy.schema:
+            raise RuntimeException(
+                'Got a spark relation with schema and database set to '
+                'include, but only one can be set'
+            )
+        return super().render()

--- a/dbt/include/spark/dbt_project.yml
+++ b/dbt/include/spark/dbt_project.yml
@@ -1,5 +1,5 @@
-
 name: dbt_spark
 version: 1.0
+config-version: 2
 
 macro-paths: ["macros"]

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -20,7 +20,7 @@
   {%- if raw_persist_docs is mapping -%}
     {%- set raw_relation = raw_persist_docs.get('relation', false) -%}
       {%- if raw_relation -%}
-      comment '{{ model.description }}'
+      comment '{{ model.description | replace("'", "\\'") }}'
       {% endif %}
   {%- else -%}
     {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ raw_persist_docs) }}
@@ -96,15 +96,15 @@
     {{ sql }}
 {% endmacro %}
 
-{% macro spark__create_schema(database_name, schema_name) -%}
+{% macro spark__create_schema(relation) -%}
   {%- call statement('create_schema') -%}
-    create schema if not exists {{schema_name}}
+    create schema if not exists {{relation}}
   {% endcall %}
 {% endmacro %}
 
-{% macro spark__drop_schema(database_name, schema_name) -%}
+{% macro spark__drop_schema(relation) -%}
   {%- call statement('drop_schema') -%}
-    drop schema if exists {{ schema_name }} cascade
+    drop schema if exists {{ relation }} cascade
   {%- endcall -%}
 {% endmacro %}
 
@@ -115,9 +115,9 @@
   {% do return(load_result('get_columns_in_relation').table) %}
 {% endmacro %}
 
-{% macro spark__list_relations_without_caching(information_schema, schema) %}
+{% macro spark__list_relations_without_caching(relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    show table extended in {{ schema }} like '*'
+    show table extended in {{ relation }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching').table) %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dbt-core==0.16.1
+dbt-core==0.17.0rc1
 PyHive[hive]>=0.6.0,<0.7.0
 thrift>=0.11.0,<0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dbt-core==0.17.0rc1
+dbt-core==0.17.0rc2
 PyHive[hive]>=0.6.0,<0.7.0
 thrift>=0.11.0,<0.12.0

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def _dbt_spark_version():
 package_version = _dbt_spark_version()
 description = """The SparkSQL plugin for dbt (data build tool)"""
 
-dbt_version = '0.16.1'
+dbt_version = '0.17.0rc1'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.16.1 vs 0.16.1a1, 0.16.1.1, ...)
+# ends of it. (0.17.0rc1 vs 0.17.0rc1a1, 0.17.0rc1.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def _dbt_spark_version():
 package_version = _dbt_spark_version()
 description = """The SparkSQL plugin for dbt (data build tool)"""
 
-dbt_version = '0.17.0rc1'
+dbt_version = '0.17.0rc2'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.17.0rc1 vs 0.17.0rc1a1, 0.17.0rc1.1, ...)
+# ends of it. (0.17.0rc2 vs 0.17.0rc2a1, 0.17.0rc2.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 import dbt.flags as flags
+from dbt.exceptions import RuntimeException
 from agate import Row
 from pyhive import hive
 from dbt.adapters.spark import SparkAdapter, SparkRelation
@@ -101,7 +102,6 @@ class TestSparkAdapter(unittest.TestCase):
         rel_type = SparkRelation.get_relation_type.Table
 
         relation = SparkRelation.create(
-            database='default_database',
             schema='default_schema',
             identifier='mytable',
             type=rel_type
@@ -182,7 +182,6 @@ class TestSparkAdapter(unittest.TestCase):
         rel_type = SparkRelation.get_relation_type.Table
 
         relation = SparkRelation.create(
-            database='default_database',
             schema='default_schema',
             identifier='mytable',
             type=rel_type
@@ -236,3 +235,33 @@ class TestSparkAdapter(unittest.TestCase):
             'stats:rows:label': 'rows',
             'stats:rows:value': 14093476,
         })
+
+    def test_relation_with_database(self):
+        config = self._get_target_http(self.project_cfg)
+        adapter = SparkAdapter(config)
+        # fine
+        adapter.Relation.create(schema='different', identifier='table')
+        with self.assertRaises(RuntimeException):
+            # not fine - database set
+            adapter.Relation.create(database='something', schema='different', identifier='table')
+
+    def test_profile_with_database(self):
+        profile = {
+            'outputs': {
+                'test': {
+                    'type': 'spark',
+                    'method': 'http',
+                    # not allowed
+                    'database': 'analytics2',
+                    'schema': 'analytics',
+                    'host': 'myorg.sparkhost.com',
+                    'port': 443,
+                    'token': 'abc123',
+                    'organization': '0123456789',
+                    'cluster': '01234-23423-coffeetime',
+                }
+            },
+            'target': 'test'
+        }
+        with self.assertRaises(RuntimeException):
+            config_from_parts_or_dicts(self.project_cfg, profile)

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -35,13 +35,14 @@ def mock_connection(name):
 
 
 def profile_from_dict(profile, profile_name, cli_vars='{}'):
-    from dbt.config import Profile, ConfigRenderer
+    from dbt.config import Profile
+    from dbt.config.renderer import ProfileRenderer
     from dbt.context.base import generate_base_context
     from dbt.utils import parse_cli_vars
     if not isinstance(cli_vars, dict):
         cli_vars = parse_cli_vars(cli_vars)
 
-    renderer = ConfigRenderer(generate_base_context(cli_vars))
+    renderer = ProfileRenderer(generate_base_context(cli_vars))
     return Profile.from_raw_profile_info(
         profile,
         profile_name,
@@ -51,12 +52,13 @@ def profile_from_dict(profile, profile_name, cli_vars='{}'):
 
 def project_from_dict(project, profile, packages=None, cli_vars='{}'):
     from dbt.context.target import generate_target_context
-    from dbt.config import Project, ConfigRenderer
+    from dbt.config import Project
+    from dbt.config.renderer import DbtProjectYamlRenderer
     from dbt.utils import parse_cli_vars
     if not isinstance(cli_vars, dict):
         cli_vars = parse_cli_vars(cli_vars)
 
-    renderer = ConfigRenderer(generate_target_context(profile, cli_vars))
+    renderer = DbtProjectYamlRenderer(generate_target_context(profile, cli_vars))
 
     project_root = project.pop('project-root', os.getcwd())
 


### PR DESCRIPTION
Fixes #78 
Fixes #81 (sort of...)

Prevent users from setting `database` just about anywhere. It would have been nice to make `database` and `schema` equivalent, like in real spark, but that requires some ugly hacks on the dbt-core end.

In the longer term, it would be nice to expose more things about `config` to plugins. Adapter specific configs can add new fields, but they can't remove them, and they can't even really check on them to see if they make sense because the builtin fields are examined before the adapter ones are considered. I'm not sure how exactly we could support such behavior in the dataclasses/hologram paradigm, but we can think about it more. Instead, the spark adapter now checks when relations are built, and errors out then. I don't think it's ideal, but it happens before dbt starts really running (when it's examining the manifest for what schemas to create) so at least there's that.

This also upgrades the plugin to ~0.17.0rc1~ 0.17.0rc2 in anticipation of the dbt 0.17.0 release - 0.17.0 support should just be a `bumpversion` away.
