### PR TITLE
Alias database to allow matching between rows and Manifest

### DIFF
--- a/dbt/adapters/spark/column.py
+++ b/dbt/adapters/spark/column.py
@@ -42,7 +42,9 @@ class SparkColumn(Column):
     def convert_table_stats(raw_stats: Optional[str]) -> Dict[str, Any]:
         table_stats = {}
         if raw_stats:
-            # format: 1109049927 bytes, 14093476 rows
+            # format:
+            #   - 1109049927 bytes, 14093476 rows
+            #   - 884216620 bytes
             stats = {
                 stats.split(" ")[1]: int(stats.split(" ")[0])
                 for stats in raw_stats.split(', ')

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -40,6 +40,9 @@ class SparkCredentials(Credentials):
     organization: str = '0'
     connect_retries: int = 0
     connect_timeout: int = 10
+    _ALIASES = {
+        'database': 'schema'
+    }
 
     def __post_init__(self):
         # spark classifies database and schema as the same thing

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -284,7 +284,7 @@ class SparkAdapter(SQLAdapter):
             if exec_only and node.resource_type not in NodeType.executable():
                 continue
             relation = self.Relation.create(
-                database=node.database,
+                database=node.schema,
                 schema=node.schema,
                 identifier='information_schema',
                 quote_policy=self.config.quoting,


### PR DESCRIPTION
Currently the docs generation is broken because we need to supply
the database name when fetching the relations:

```python
if dct['table_database'] is None:
    dct['table_database'] = dct['table_schema']
```

However, when we get the manifest we don't get the database:

```
{CatalogKey(database='', schema='fokko', name='logistical_configuration_data'):
	['model.dbtlake.logistical_configuration_data']}
```

Therefore the keys never line up, and we can't match the Catalogs:

https://github.com/fishtown-analytics/dbt/blob/9d0eab630511723cd0bc328f6f11d3ffe6c8f879/core/dbt/task/generate.py#L108

We get from the describe relations:

```
CatalogKey(database='fokko', schema='fokko', name='logistical_configuration_data')
```

Due to the logic above. I think `ALIASing` this is the easiest way out. Making the database non-optional in core would be another option, that would be cleaner in the long run. Please advise.