### PR TITLE
Better messaging for older Spark versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 
 # dbt-spark
 
+This plugin ports [dbt](https://getdbt.com) functionality to Spark. It supports
+running dbt against Spark clusters that are hosted via Databricks (AWS + Azure), 
+Amazon EMR, or Docker.
+
+We have not tested extensively against older versions of Apache Spark. The
+plugin uses syntax that requires version 2.2.0 or newer.
+
 ### Documentation
 For more information on using Spark with dbt, consult the dbt documentation:
 - [Spark profile](https://docs.getdbt.com/docs/profile-spark)

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -123,7 +123,13 @@ class SparkAdapter(SQLAdapter):
                 return []
 
         relations = []
-        for _schema, name, _, information in results:
+        for row in results:
+            if len(row) != 4:
+                raise dbt.exceptions.RuntimeException(
+                    f'Invalid value from "show table extended ...", '
+                    f'got {len(row)} values, expected 4'
+                )
+            _schema, name, _, information = row
             rel_type = ('view' if 'Type: VIEW' in information else 'table')
             relation = self.Relation.create(
                 schema=_schema,


### PR DESCRIPTION
* Resolves #71
* Add a note to README about min required Spark version (we think 2.2.0). We could add a more codified version check/requirement, but since we don't have a _great_ sense of what all historical versions we do/don't support, I think a disclaimer is enough for now.
* Raise a better error message if `show table extended in database ... like '*'` returns fewer columns than expected (4). It seems to return 2 columns on older Spark versions (< 2.2.0).