### PR TITLE
The organisation is an integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A dbt profile can be configured to run against Spark using the following configu
 | host    | The hostname to connect to                         | Required                | `yourorg.sparkhost.com`  |
 | port    | The port to connect to the host on                 | Optional (default: 443 for `http`, 10001 for `thrift`) | `443`                    |
 | token   | The token to use for authenticating to the cluster | Required for `http`                | `abc123`                 |
-| organization | The id of the Azure Databricks workspace being used; only for  Azure Databricks | See Databricks Note | `1234567891234567` |
+| organization | The id of the Azure Databricks workspace being used | Required for Azure Databricks | `1234567891234567` |
 | cluster | The name of the cluster to connect to              | Required for `http`               | `01234-23423-coffeetime` |
 | user    | The username to use to connect to the cluster  | Optional  | `hadoop`  |
 | connect_timeout | The number of seconds to wait before retrying to connect to a Pending Spark cluster | Optional (default: 10) | `60` |
@@ -57,7 +57,7 @@ A dbt profile can be configured to run against Spark using the following configu
 
 AWS and Azure Databricks have differences in their connections, likely due to differences in how their URLs are generated between the two services.
 
-**Organization:** To connect to an Azure Databricks cluster, you will need to obtain your organization ID, which is a unique ID Azure Databricks generates for each customer workspace.  To find the organization ID, see https://docs.microsoft.com/en-us/azure/databricks/dev-tools/databricks-connect#step-2-configure-connection-properties. This is a string field; if there is a leading zero, be sure to include it.
+**Organization:** To connect to the Azure Databricks, you will need to obtain your organization ID, which is a unique ID Azure Databricks generates for the workspace. The organisation is [included in the url](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/databricks-connect#step-2-configure-connection-properties), for example, `?o=1234567891234567`.
 
 **Port:** Please ignore all references to port 15001 in the databricks-connect docs as that is specific to that tool; port 443 is used for dbt-spark's https connection.
 

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -37,7 +37,7 @@ class SparkCredentials(Credentials):
     token: Optional[str] = None
     user: Optional[str] = None
     port: int = 443
-    organization: str = '0'
+    organization: int = 0
     connect_retries: int = 0
     connect_timeout: int = 10
 

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -35,7 +35,7 @@ class TestSparkAdapter(unittest.TestCase):
                     'host': 'myorg.sparkhost.com',
                     'port': 443,
                     'token': 'abc123',
-                    'organization': '0123456789',
+                    'organization': 123456789,
                     'cluster': '01234-23423-coffeetime',
                 }
             },
@@ -65,7 +65,7 @@ class TestSparkAdapter(unittest.TestCase):
             self.assertEqual(thrift_transport.scheme, 'https')
             self.assertEqual(thrift_transport.port, 443)
             self.assertEqual(thrift_transport.host, 'myorg.sparkhost.com')
-            self.assertEqual(thrift_transport.path, '/sql/protocolv1/o/0123456789/01234-23423-coffeetime')
+            self.assertEqual(thrift_transport.path, '/sql/protocolv1/o/123456789/01234-23423-coffeetime')
 
         # with mock.patch.object(hive, 'connect', new=hive_http_connect):
         with mock.patch('dbt.adapters.spark.connections.hive.connect', new=hive_http_connect):
@@ -259,7 +259,7 @@ class TestSparkAdapter(unittest.TestCase):
                     'host': 'myorg.sparkhost.com',
                     'port': 443,
                     'token': 'abc123',
-                    'organization': '0123456789',
+                    'organization': 123456789,
                     'cluster': '01234-23423-coffeetime',
                 }
             },


### PR DESCRIPTION
While rebasing https://github.com/fishtown-analytics/dbt-spark/pull/85 against the latest master, I've encountered an issue with the connection:
```
root@f425d97e576a:/dbtlake# dbt docs generate
Running with dbt=0.17.0-rc2
Encountered an error while reading profiles:
  ERROR Runtime Error
  Credentials in profile "default", target "dev" invalid: 1285381041234567 is not of type 'string'
Defined profiles:
 - default
```

With the following config (slightly modified of course):
```
 default:
   target: dev
   outputs:
     dev:
       method: http
       type: spark
       schema: fokko
       organization: "1285381041234567"
       host: "westeurope.azuredatabricks.net"
       port: 443
       token: "..."
       cluster: "..."
       connect_retries: 20
       connect_timeout: 60
       threads: 8

 config:
   send_anonymous_usage_stats: False
```