### PR TITLE
Always set database = schema

### DIFF
--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -132,6 +132,7 @@ class SparkAdapter(SQLAdapter):
             _schema, name, _, information = row
             rel_type = ('view' if 'Type: VIEW' in information else 'table')
             relation = self.Relation.create(
+                database=_schema,
                 schema=_schema,
                 identifier=name,
                 type=rel_type

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -27,14 +27,7 @@ class SparkRelation(BaseRelation):
     def __post_init__(self):
         # some core things set database='', which we should ignore.
         if self.database and self.database != self.schema:
-            raise RuntimeException(
-                f'Error while parsing relation {self.name}: \n'
-                f'    identifier: {self.identifier} \n'
-                f'    schema: {self.schema} \n'
-                f'    database: {self.database} \n'
-                f'On Spark, database should not be set. Use the schema '
-                f'config to set a custom schema/database for this relation.'
-            )
+            self.__dict__['path'] = self.path.incorporate(database = self.schema)
 
     def render(self):
         if self.include_policy.database and self.include_policy.schema:


### PR DESCRIPTION
* closes #85
* resolves #89

### Problems

* If the catalog and the manifest are not in full agreement about the database value of a given node/relation, the auto-generated docs site will be missing information (see #85)
* Sources and snapshots which declare a `schema`/`target_schema`, but which do not also declare an identical `database`/`target_database`, return the exception we _intended_ to only appear when a user has specified a model config `database` that differs from the model's configured `schema` (see #89)

### Approaches

1. Always set `database = ''`
    * Upside: By checking if a node or relation has `database != ''`, we can see if the user has manually set the `database` config, allowing us to raise an appropriate exception.
    * Downside: All relations now have the same `database`. When it comes time for docs generation, `_get_one_catalog` is passed a single database with multiple schemas, raising the exception `'Expected only one schema in spark _get_one_catalog'`. This exception is well motivated; on Spark, we need to run a separate `list_relations` query for each database/schema.

2. Always set `database = schema`
    * Upside: dbt _should_ be able to know that relations in different schemas are in different databases for the purposes of running separate `list_relations` queries.
    * Upside: This is more in line with Spark's conceptual model.
    * Downside: If a relation's database != schema, there's no good way to know if this is because the user set both to be different, or because a source/snapshot simply has a `schema`/`target_schema` that differs from the default database (`target.database`). We can't raise a helpful exception in the event that the user is trying funky things with the `database` config; we'll just need to document this.

I think I prefer the second approach, and I've tried to implement it here. I figured out a way to change the value of `database` via `__post_init__` even though `SparkRelation` is inhering a frozen dataclass.

_However_, `dbt docs generate` is still returning this error:
```
Encountered an error while generating catalog: Compilation Error
  Expected only one schema in spark _get_one_catalog
dbt encountered 1 failure while writing the catalog
```

My best guess right now:
* `_get_catalog_schemas` uses the `create_from` classmethod from BaseRelation to create `info_schema_name_map`, i.e. the object which establishes which relations exist in which schemas in which databases
* `create_from` --> `create_from_node` does not respect my `__post_init__` resetting of database = schema, instead pulling the values of database, schema, etc directly off the node attributes.

@beckjake I'd be thrilled if you could check this out and help me debug what's going wrong. As it is, we may need to revisit some of the catalog generation methods in light of #90.