### PR TITLE
Added sample_profiles.yml so that adapter works with new --adapter option of dbt init

### DIFF
--- a/dbt/include/spark/sample_profiles.yml
+++ b/dbt/include/spark/sample_profiles.yml
@@ -1,0 +1,14 @@
+your_profile_name:
+  target: dev
+  outputs:
+    dev:
+      method: http
+      type: spark
+      schema: analytics
+      host: yourorg.sparkhost.com
+      organization: 1234567891234567    # Azure Databricks ONLY
+      port: 443
+      token: abc123
+      cluster: 01234-23423-coffeetime
+      connect_retries: 5
+      connect_timeout: 60

--- a/dbt/include/spark/sample_profiles.yml
+++ b/dbt/include/spark/sample_profiles.yml
@@ -1,9 +1,10 @@
 your_profile_name:
-  target: dev
   outputs:
-    dev:
-      method: http
+
+    # Use this if connecting to a hosted spark (e.g. Databricks)
+    dev_http:
       type: spark
+      method: http
       schema: analytics
       host: yourorg.sparkhost.com
       organization: 1234567891234567    # Azure Databricks ONLY
@@ -12,3 +13,16 @@ your_profile_name:
       cluster: 01234-23423-coffeetime
       connect_retries: 5
       connect_timeout: 60
+
+    # Use this if connecting to Dockerized spark
+    dev_thrift:
+      type: spark
+      method: thrift
+      schema: analytics
+      host: 127.0.0.1
+      port: 10001
+      user: hadoop
+      connect_retries: 5
+      connect_timeout: 60
+
+  target: dev

--- a/dbt/include/spark/sample_profiles.yml
+++ b/dbt/include/spark/sample_profiles.yml
@@ -1,28 +1,24 @@
-your_profile_name:
+default:
   outputs:
 
     # Use this if connecting to a hosted spark (e.g. Databricks)
-    dev_http:
+    dev:
       type: spark
       method: http
-      schema: analytics
-      host: yourorg.sparkhost.com
-      organization: 1234567891234567    # Azure Databricks ONLY
-      port: 443
-      token: abc123
-      cluster: 01234-23423-coffeetime
-      connect_retries: 5
-      connect_timeout: 60
+      schema: [dev_schema]
+      host: [host]
+      organization: [organization id]    # Azure Databricks ONLY
+      port: [port]
+      token: [token]
+      cluster: [cluster id]
 
     # Use this if connecting to Dockerized spark
-    dev_thrift:
+    prod:
       type: spark
       method: thrift
-      schema: analytics
-      host: 127.0.0.1
-      port: 10001
-      user: hadoop
-      connect_retries: 5
-      connect_timeout: 60
+      schema: [dev_schema]
+      host: [host]
+      port: [port]
+      user: [prod_user]
 
   target: dev

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     package_data={
         'dbt': [
             'include/spark/dbt_project.yml',
+            'include/spark/sample_profiles.yml',
             'include/spark/macros/*.sql',
             'include/spark/macros/**/*.sql',
         ]


### PR DESCRIPTION
resolves [#2533](https://github.com/fishtown-analytics/dbt/issues/2533)


### Description

Added option '--adapter' to `dbt init`, to create sample profiles.yml based on chosen adapter.

It gets the sample profiles.yml from the adapter 'includes' folder