### PR TITLE
Bump v0.17.2

### DIFF
--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.2rc1
+current_version = 0.17.2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.2rc1
+current_version = 0.17.2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "0.17.1"
+version = "0.17.2rc1"

--- a/dbt/adapters/spark/__version__.py
+++ b/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "0.17.2rc1"
+version = "0.17.2"

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -112,8 +112,7 @@ class SparkAdapter(SQLAdapter):
         try:
             results = self.execute_macro(
                 LIST_RELATIONS_MACRO_NAME,
-                kwargs=kwargs,
-                release=True
+                kwargs=kwargs
             )
         except dbt.exceptions.RuntimeException as e:
             errmsg = getattr(e, 'msg', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dbt-core==0.17.2rc1
+dbt-core==0.17.2
 PyHive[hive]>=0.6.0,<0.7.0
 thrift>=0.11.0,<0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dbt-core==0.17.1
+dbt-core==0.17.2rc1
 PyHive[hive]>=0.6.0,<0.7.0
 thrift>=0.11.0,<0.12.0

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def _dbt_spark_version():
 package_version = _dbt_spark_version()
 description = """The SparkSQL plugin for dbt (data build tool)"""
 
-dbt_version = '0.17.2rc1'
+dbt_version = '0.17.2'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.17.2rc1 vs 0.17.2rc1a1, 0.17.2rc1.1, ...)
+# ends of it. (0.17.2 vs 0.17.2a1, 0.17.2.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ def _dbt_spark_version():
 package_version = _dbt_spark_version()
 description = """The SparkSQL plugin for dbt (data build tool)"""
 
-dbt_version = '0.17.1'
+dbt_version = '0.17.2rc1'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.17.1 vs 0.17.1a1, 0.17.1.1, ...)
+# ends of it. (0.17.2rc1 vs 0.17.2rc1a1, 0.17.2rc1.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '


### PR DESCRIPTION
Remove the `release` argument from `execute_macro`. Everything worked fine with or without it. While I left it in, I saw the deprecation warning:
```
* Deprecation Warning: The "release" argument to execute_macro is now ignored,
and will be removed in a future relase of dbt. At that time, providing a
`release` argument will result in an error.
```

Leaving as a draft until we release dbt v0.17.2.