### PR TITLE
allow kerberos

### DIFF
--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -37,6 +37,8 @@ class SparkCredentials(Credentials):
     token: Optional[str] = None
     user: Optional[str] = None
     port: int = 443
+    auth: Optional[str]=None
+    kerberos_service_name: Optional[str]=None
     organization: str = '0'
     connect_retries: int = 0
     connect_timeout: int = 10
@@ -269,7 +271,9 @@ class SparkConnectionManager(SQLConnectionManager):
 
                     conn = hive.connect(host=creds.host,
                                         port=creds.port,
-                                        username=creds.user)
+                                        username=creds.user,
+                                        auth=creds.auth,
+                                        kerberos_service_name=creds.kerberos_service_name)
                 else:
                     raise dbt.exceptions.DbtProfileError(
                         f"invalid credential method: {creds.method}"


### PR DESCRIPTION
Fixes https://github.com/fishtown-analytics/dbt-spark/issues/106

Allows users to specify auth and kerberos_service_name.  This won't impact existing users who upgrade. 

