### PR TITLE
Support for ODBC driver connection type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,24 @@ jobs:
       - checkout
       - run:
           name: Run integration tests
-          command: tox -e integration-spark-databricks
+          command: tox -e integration-spark-databricks-http
           no_output_timeout: 1h
       - store_artifacts:
           path: ./logs
+
+  # integration-spark-databricks-odbc:
+  #   environment:
+  #     DBT_INVOCATION_ENV: circle
+  #   docker:
+  #     - image: kwigley/spark-test-container:1
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Run integration tests
+  #         command: ODBC_DRIVER=Simba tox -e integration-spark-databricks-odbc-cluster,integration-spark-databricks-odbc-sql-endpoint
+  #         no_output_timeout: 1h
+  #     - store_artifacts:
+  #         path: ./logs
 
 workflows:
   version: 2
@@ -71,3 +85,6 @@ workflows:
       - integration-spark-databricks:
           requires:
             - unit
+      # - integration-spark-databricks-odbc:
+      #     requires:
+      #       - unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,17 +63,12 @@ jobs:
   integration-spark-databricks-odbc:
     environment:
       DBT_INVOCATION_ENV: circle
-      ODBC_DRIVER: Simba
-      ODBC_DRIVER_URL: https://databricks.com/wp-content/uploads/drivers-2020/SimbaSparkODBC-2.6.16.1019-Debian-64bit.zip
+      ODBC_DRIVER: Simba # TODO: move to env var to test image
     docker:
-      - image: fishtownanalytics/test-container:10
-        command: |
-          curl -L $ODBC_DRIVER_URL > /tmp/simba_odbc.zip
-          unzip /tmp/simba_odbc.zip -d /tmp/
-          dpkg -i /tmp/SimbaSparkODBC-*/*.deb
-          echo "[$ODBC_DRIVER]\nDriver = /opt/simba/spark/lib/64/libsparkodbc_sb64.so" >> /etc/odbcinst.ini
-          rm /tmp/simba_odbc.zip
-          rm -rf /tmp/SimbaSparkODBC*
+      - image: 828731156495.dkr.ecr.us-east-1.amazonaws.com/dbt-spark-odbc-test-container:latest
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID_STAGING
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY_STAGING
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       DBT_INVOCATION_ENV: circle
     docker:
-      - image: fishtownanalytics/test-container:9
+      - image: fishtownanalytics/test-container:10
     steps:
       - checkout
       - run: tox -e flake8,unit
@@ -14,7 +14,7 @@ jobs:
     environment:
       DBT_INVOCATION_ENV: circle
     docker:
-      - image: fishtownanalytics/test-container:9
+      - image: fishtownanalytics/test-container:10
       - image: godatadriven/spark:2
         environment:
           WAIT_FOR: localhost:5432
@@ -46,11 +46,11 @@ jobs:
       - store_artifacts:
           path: ./logs
 
-  integration-spark-databricks:
+  integration-spark-databricks-http:
     environment:
       DBT_INVOCATION_ENV: circle
     docker:
-      - image: fishtownanalytics/test-container:9
+      - image: fishtownanalytics/test-container:10
     steps:
       - checkout
       - run:
@@ -60,19 +60,28 @@ jobs:
       - store_artifacts:
           path: ./logs
 
-  # integration-spark-databricks-odbc:
-  #   environment:
-  #     DBT_INVOCATION_ENV: circle
-  #   docker:
-  #     - image: kwigley/spark-test-container:1
-  #   steps:
-  #     - checkout
-  #     - run:
-  #         name: Run integration tests
-  #         command: ODBC_DRIVER=Simba tox -e integration-spark-databricks-odbc-cluster,integration-spark-databricks-odbc-sql-endpoint
-  #         no_output_timeout: 1h
-  #     - store_artifacts:
-  #         path: ./logs
+  integration-spark-databricks-odbc:
+    environment:
+      DBT_INVOCATION_ENV: circle
+      ODBC_DRIVER: Simba
+      ODBC_DRIVER_URL: https://databricks.com/wp-content/uploads/drivers-2020/SimbaSparkODBC-2.6.16.1019-Debian-64bit.zip
+    docker:
+      - image: fishtownanalytics/test-container:10
+        command: |
+          curl -L $ODBC_DRIVER_URL > /tmp/simba_odbc.zip
+          unzip /tmp/simba_odbc.zip -d /tmp/
+          dpkg -i /tmp/SimbaSparkODBC-*/*.deb
+          echo "[$ODBC_DRIVER]\nDriver = /opt/simba/spark/lib/64/libsparkodbc_sb64.so" >> /etc/odbcinst.ini
+          rm /tmp/simba_odbc.zip
+          rm -rf /tmp/SimbaSparkODBC*
+    steps:
+      - checkout
+      - run:
+          name: Run integration tests
+          command: tox -e integration-spark-databricks-odbc-cluster,integration-spark-databricks-odbc-sql-endpoint
+          no_output_timeout: 1h
+      - store_artifacts:
+          path: ./logs
 
 workflows:
   version: 2
@@ -82,9 +91,9 @@ workflows:
       - integration-spark-thrift:
           requires:
             - unit
-      - integration-spark-databricks:
+      - integration-spark-databricks-http:
           requires:
             - unit
-      # - integration-spark-databricks-odbc:
-      #     requires:
-      #       - unit
+      - integration-spark-databricks-odbc:
+          requires:
+            - unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
       DBT_INVOCATION_ENV: circle
       ODBC_DRIVER: Simba # TODO: move to env var to test image
     docker:
+      # image based on `fishtownanalytics/test-container` w/ Simba ODBC Spark driver installed
       - image: 828731156495.dkr.ecr.us-east-1.amazonaws.com/dbt-spark-odbc-test-container:latest
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID_STAGING

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
   integration-spark-databricks-odbc:
     environment:
       DBT_INVOCATION_ENV: circle
-      ODBC_DRIVER: Simba # TODO: move to env var to test image
+      ODBC_DRIVER: Simba # TODO: move env var to Docker image
     docker:
       # image based on `fishtownanalytics/test-container` w/ Simba ODBC Spark driver installed
       - image: 828731156495.dkr.ecr.us-east-1.amazonaws.com/dbt-spark-odbc-test-container:latest

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 dbt-integration-tests
 test/integration/.user.yml
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ pip install dbt-spark
 dbt-spark also supports connections via ODBC driver, but it requires [`pyodbc`](https://github.com/mkleehammer/pyodbc). You can install it seperately or via pip as well:
 
 ```bash
-# Install dbt-spark from PyPi:
+# Install dbt-spark w/ pyodbc from PyPi:
 $ pip install "dbt-spark[ODBC]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,14 @@ your_profile_name:
       organization: 1234567891234567    # Azure Databricks ONLY
       port: 443
       token: abc123
+
+      # one of:
       cluster: 01234-23423-coffeetime
+      endpoint: coffee01234time
+
       driver: path/to/driver
-      connect_retries: 5
-      connect_timeout: 60
+      connect_retries: 5    # cluster only
+      connect_timeout: 60   # cluster only
 ```
 
 

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -11,7 +11,10 @@ from dbt.adapters.spark import __version__
 from TCLIService.ttypes import TOperationState as ThriftState
 from thrift.transport import THttpClient
 from pyhive import hive
-import pyodbc
+try:
+    import pyodbc
+except ImportError:
+    pyodbc = None
 from datetime import datetime
 import sqlparams
 
@@ -66,6 +69,14 @@ class SparkCredentials(Credentials):
                 f' schema.'
             )
         self.database = None
+
+        if self.method == SparkConnectionMethod.ODBC and pyodbc is None:
+            raise dbt.exceptions.RuntimeException(
+                f"{self.method} connection method requires "
+                "additional dependencies. \n"
+                "Install the additional required dependencies with "
+                "`pip install dbt-spark[ODBC]`"
+            )
 
     @property
     def type(self):

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -10,6 +10,6 @@ pytest-xdist>=2.1.0,<3
 flaky>=3.5.3,<4
 
 # Test requirements
-pytest-dbt-adapter==0.2.0
+pytest-dbt-adapter==0.3.0
 sasl==0.2.1
 thrift_sasl==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dbt-core==0.18.0
 PyHive[hive]>=0.6.0,<0.7.0
 thrift>=0.11.0,<0.12.0
+pyodbc>=4.0.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dbt-core==0.18.0
 PyHive[hive]>=0.6.0,<0.7.0
-thrift>=0.11.0,<0.12.0
 pyodbc>=4.0.30
+sqlparams>=3.0.0
+thrift>=0.11.0,<0.12.0

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
         f'dbt-core=={dbt_version}',
         'PyHive[hive]>=0.6.0,<0.7.0',
         'thrift>=0.11.0,<0.12.0',
+        'pyodbc>=4.0.30',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setup(
     install_requires=[
         f'dbt-core=={dbt_version}',
         'PyHive[hive]>=0.6.0,<0.7.0',
-        'thrift>=0.11.0,<0.12.0',
         'pyodbc>=4.0.30',
+        'sqlparams>=3.0.0',
+        'thrift>=0.11.0,<0.12.0'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,10 @@ setup(
     install_requires=[
         f'dbt-core=={dbt_version}',
         'PyHive[hive]>=0.6.0,<0.7.0',
-        'pyodbc>=4.0.30',
         'sqlparams>=3.0.0',
         'thrift>=0.11.0,<0.12.0'
-    ]
+    ],
+    extra_requires={
+        "ODBC":  ['pyodbc>=4.0.30'],
+    }
 )

--- a/test/integration/spark-databricks-http.dbtspec
+++ b/test/integration/spark-databricks-http.dbtspec
@@ -3,8 +3,7 @@ target:
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
   cluster: "{{ env_var('DBT_DATABRICKS_CLUSTER_NAME') }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
-  method: odbc
-  driver: "{{ env_var('ODBC_DRIVER') }}"
+  method: http
   port: 443
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   connect_retries: 5
@@ -18,7 +17,7 @@ projects:
     facts:
       base:
         rowcount: 10
-      extended:
+      added:
         rowcount: 20
   - overrides: snapshot_strategy_check_cols
     dbt_project_yml: &file_format_delta
@@ -32,4 +31,13 @@ projects:
   - overrides: snapshot_strategy_timestamp
     dbt_project_yml: *file_format_delta
 sequences:
+  test_dbt_empty: empty
+  test_dbt_base: base
+  test_dbt_ephemeral: ephemeral
   test_dbt_incremental: incremental
+  test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_data_test: data_test
+  test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+  test_dbt_schema_test: schema_test
+

--- a/test/integration/spark-databricks-odbc-cluster.dbtspec
+++ b/test/integration/spark-databricks-odbc-cluster.dbtspec
@@ -3,7 +3,8 @@ target:
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
   cluster: "{{ env_var('DBT_DATABRICKS_CLUSTER_NAME') }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
-  method: http
+  method: odbc
+  driver: "{{ env_var('ODBC_DRIVER') }}"
   port: 443
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   connect_retries: 5
@@ -17,7 +18,7 @@ projects:
     facts:
       base:
         rowcount: 10
-      extended:
+      added:
         rowcount: 20
   - overrides: snapshot_strategy_check_cols
     dbt_project_yml: &file_format_delta
@@ -40,4 +41,3 @@ sequences:
   test_dbt_data_test: data_test
   test_dbt_ephemeral_data_tests: data_test_ephemeral_models
   test_dbt_schema_test: schema_test
-

--- a/test/integration/spark-databricks-odbc-sql-endpoint.dbtspec
+++ b/test/integration/spark-databricks-odbc-sql-endpoint.dbtspec
@@ -1,0 +1,44 @@
+target:
+  type: spark
+  host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
+  endpoint: "{{ env_var('DBT_DATABRICKS_ENDPOINT') }}"
+  token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
+  method: odbc
+  driver: "{{ env_var('ODBC_DRIVER') }}"
+  port: 443
+  schema: "analytics_{{ var('_dbt_random_suffix') }}"
+  connect_retries: 5
+  connect_timeout: 60
+projects:
+  - overrides: incremental
+    paths:
+      "models/incremental.sql":
+        materialized: incremental
+        body: "select * from {{ source('raw', 'seed') }}"
+    facts:
+      base:
+        rowcount: 10
+      added:
+        rowcount: 20
+  - overrides: snapshot_strategy_check_cols
+    dbt_project_yml: &file_format_delta
+      # we're going to UPDATE the seed tables as part of testing, so we must make them delta format
+      seeds:
+        dbt_test_project:
+          file_format: delta
+      snapshots:
+        dbt_test_project:
+          file_format: delta
+  - overrides: snapshot_strategy_timestamp
+    dbt_project_yml: *file_format_delta
+sequences:
+  test_dbt_empty: empty
+  test_dbt_base: base
+  test_dbt_ephemeral: ephemeral
+  # The SQL Endpoint does not support `create temporary view`
+  # test_dbt_incremental: incremental
+  test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_data_test: data_test
+  test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+  test_dbt_schema_test: schema_test

--- a/test/integration/spark-databricks-odbc.dbtspec
+++ b/test/integration/spark-databricks-odbc.dbtspec
@@ -1,0 +1,35 @@
+target:
+  type: spark
+  host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
+  cluster: "{{ env_var('DBT_DATABRICKS_CLUSTER_NAME') }}"
+  token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
+  method: odbc
+  driver: /Library/simba/spark/lib/libsparkodbc_sbu.dylib
+  port: 443
+  schema: "analytics_{{ var('_dbt_random_suffix') }}"
+  connect_retries: 5
+  connect_timeout: 60
+projects:
+  - overrides: incremental
+    paths:
+      "models/incremental.sql":
+        materialized: incremental
+        body: "select * from {{ source('raw', 'seed') }}"
+    facts:
+      base:
+        rowcount: 10
+      extended:
+        rowcount: 20
+  - overrides: snapshot_strategy_check_cols
+    dbt_project_yml: &file_format_delta
+      # we're going to UPDATE the seed tables as part of testing, so we must make them delta format
+      seeds:
+        dbt_test_project:
+          file_format: delta
+      snapshots:
+        dbt_test_project:
+          file_format: delta
+  - overrides: snapshot_strategy_timestamp
+    dbt_project_yml: *file_format_delta
+sequences:
+  test_dbt_incremental: incremental

--- a/test/integration/spark-databricks-odbc.dbtspec
+++ b/test/integration/spark-databricks-odbc.dbtspec
@@ -4,7 +4,7 @@ target:
   cluster: "{{ env_var('DBT_DATABRICKS_CLUSTER_NAME') }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
   method: odbc
-  driver: /Library/simba/spark/lib/libsparkodbc_sbu.dylib
+  driver: "{{ env_var('ODBC_DRIVER') }}"
   port: 443
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   connect_retries: 5

--- a/test/integration/spark-thrift.dbtspec
+++ b/test/integration/spark-thrift.dbtspec
@@ -16,7 +16,7 @@ projects:
     facts:
       base:
         rowcount: 10
-      extended:
+      added:
         rowcount: 20
 sequences:
   test_dbt_empty: empty

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,16 @@ deps =
     -r{toxinidir}/dev_requirements.txt
     -e.
 
+[testenv:integration-spark-databricks-odbc]
+basepython = python3
+commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-databricks-odbc.dbtspec'
+passenv = DBT_DATABRICKS_HOST_NAME DBT_DATABRICKS_CLUSTER_NAME DBT_DATABRICKS_TOKEN DBT_INVOCATION_ENV
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/dev_requirements.txt
+    -e.
+
+
 [testenv:integration-spark-thrift]
 basepython = python3
 commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark.dbtspec'

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
 [testenv:integration-spark-databricks-odbc]
 basepython = python3
 commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-databricks-odbc.dbtspec'
-passenv = DBT_DATABRICKS_HOST_NAME DBT_DATABRICKS_CLUSTER_NAME DBT_DATABRICKS_TOKEN DBT_INVOCATION_ENV
+passenv = DBT_DATABRICKS_HOST_NAME DBT_DATABRICKS_CLUSTER_NAME DBT_DATABRICKS_TOKEN DBT_INVOCATION_ENV ODBC_DRIVER
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -18,19 +18,28 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
 
-[testenv:integration-spark-databricks]
+[testenv:integration-spark-databricks-http]
 basepython = python3
-commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-databricks.dbtspec'
+commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-databricks-http.dbtspec'
 passenv = DBT_DATABRICKS_HOST_NAME DBT_DATABRICKS_CLUSTER_NAME DBT_DATABRICKS_TOKEN DBT_INVOCATION_ENV
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
     -e.
 
-[testenv:integration-spark-databricks-odbc]
+[testenv:integration-spark-databricks-odbc-cluster]
 basepython = python3
-commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-databricks-odbc.dbtspec'
+commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-databricks-odbc-cluster.dbtspec'
 passenv = DBT_DATABRICKS_HOST_NAME DBT_DATABRICKS_CLUSTER_NAME DBT_DATABRICKS_TOKEN DBT_INVOCATION_ENV ODBC_DRIVER
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/dev_requirements.txt
+    -e.
+
+[testenv:integration-spark-databricks-odbc-sql-endpoint]
+basepython = python3
+commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-databricks-odbc-sql-endpoint.dbtspec'
+passenv = DBT_DATABRICKS_HOST_NAME DBT_DATABRICKS_ENDPOINT DBT_DATABRICKS_TOKEN DBT_INVOCATION_ENV ODBC_DRIVER
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -39,7 +48,7 @@ deps =
 
 [testenv:integration-spark-thrift]
 basepython = python3
-commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark.dbtspec'
+commands = /bin/bash -c '{envpython} -m pytest -v test/integration/spark-thrift.dbtspec'
 passenv = DBT_INVOCATION_ENV
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Resolves #104

### Description
Add support for ODBC driver connections with Databricks via cluster specific path and sql endpoint path.

- add `pyodbc` for using ODBC driver for connection
- add `driver` and `endpoint` to profile config (`cluster` and `endpoint` are mutually exclusive, they determine how to connect to Databricks)
- add integration and unit tests
  - because this connection method uses a driver, I created a new image with the driver installed for integration tests to use. TBD where this Dockerfile lives!

### Note
At the time of writing this, the new SQL Endpoint does not support `create temporary view`. Also, `extended` is prohibited by the ODBC driver for some operations https://github.com/fishtown-analytics/dbt-adapter-tests/pull/8