### PR TITLE
replace partitionOverwriteMode inside merge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The following configurations can be supplied to models run with the dbt-spark pl
 **Incremental Models**
 
 To use incremental models, specify a `partition_by` clause in your model config. The default incremental strategy used is `insert_overwrite`, which will overwrite the partitions included in your query. Be sure to re-select _all_ of the relevant
-data for a partition when using the `insert_overwrite` strategy.
+data for a partition when using the `insert_overwrite` strategy. If a `partition_by` config is not specified, dbt will overwrite the entire table as an atomic operation, replacing it with new data of the same schema. This is analogous to `truncate` + `insert`.
 
 ```
 {{ config(

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -97,12 +97,11 @@
 
   {% if strategy == 'merge' %}
     {%- set unique_key = config.require('unique_key') -%}
+    {% call statement() %}
+      set spark.sql.sources.partitionOverwriteMode = DYNAMIC
+    {% endcall %}
     {% do dbt_spark_validate_merge(file_format) %}
   {% endif %}
-
-  {% call statement() %}
-    set spark.sql.sources.partitionOverwriteMode = DYNAMIC
-  {% endcall %}
 
   {% call statement() %}
     set spark.sql.hive.convertMetastoreParquet = false

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -62,7 +62,6 @@
 
 
 {% macro spark__get_merge_sql(target, source, unique_key, dest_columns, predicates=none) %}
-  
   {# ignore dest_columns - we will just use `*` #}
     merge into {{ target }} as DBT_INTERNAL_DEST
       using {{ source.include(schema=false) }} as DBT_INTERNAL_SOURCE

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -62,6 +62,7 @@
 
 
 {% macro spark__get_merge_sql(target, source, unique_key, dest_columns, predicates=none) %}
+  
   {# ignore dest_columns - we will just use `*` #}
     merge into {{ target }} as DBT_INTERNAL_DEST
       using {{ source.include(schema=false) }} as DBT_INTERNAL_SOURCE
@@ -97,10 +98,13 @@
 
   {% if strategy == 'merge' %}
     {%- set unique_key = config.require('unique_key') -%}
+    {% do dbt_spark_validate_merge(file_format) %}
+  {% endif %}
+
+  {% if unique_key or config.get('partition_by') %}
     {% call statement() %}
       set spark.sql.sources.partitionOverwriteMode = DYNAMIC
     {% endcall %}
-    {% do dbt_spark_validate_merge(file_format) %}
   {% endif %}
 
   {% call statement() %}


### PR DESCRIPTION
**Problem:** 
Using incremental materialization with a insert_overwrite strategy without a unique_key doesn't work. 
```
{{
  config(
    materialized='incremental',
    file_format='delta',
    incremental_strategy='insert_overwrite'
  )
}}
```
**Error message**  
 Table charlotte.test does not support dynamic overwrite in batch mode.

**Fix**  
Relocating the "spark.sql.sources.partitionOverwriteMode = DYNAMIC" inside the merge strategy. Because this is only necessary when you give a unique_key, and for insert_overwrite this is not a must, but for merge it is.


