### PR TITLE
Fix issue when installing pyodbc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'sqlparams>=3.0.0',
         'thrift>=0.11.0,<0.12.0'
     ],
-    extra_requires={
+    extras_require={
         "ODBC":  ['pyodbc>=4.0.30'],
     }
 )


### PR DESCRIPTION
resolves #122 

before:
```bash
pip install ".[ODBC]"
Processing /Users/kwigley/workspace/dbt-spark
  WARNING: dbt-spark 0.18.1 does not provide the extra 'odbc'
# no pyodbc
```
after:
```bash
pip install ".[ODBC]"
Processing /Users/kwigley/workspace/dbt-spark
# no warning
...
Successfully installed ... pyodbc-4.0.30 ...
```