### PR TITLE
Move PyHive requirement to extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-spark 0.19.0 (Release TBD)
 
+### Breaking changes
+- Users of the `http` and `thrift` connection methods need to install extra requirements: `pip install dbt-spark[PyHive]` ([#109](https://github.com/fishtown-analytics/dbt-spark/pull/109), [#126](https://github.com/fishtown-analytics/dbt-spark/pull/126))
+
 ### Under the hood
 - Add changelog, issue templates ([#119](https://github.com/fishtown-analytics/dbt-spark/pull/119), [#120](https://github.com/fishtown-analytics/dbt-spark/pull/120))
 

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,13 @@ setup(
     },
     install_requires=[
         f'dbt-core=={dbt_version}',
-        'PyHive[hive]>=0.6.0,<0.7.0',
         'sqlparams>=3.0.0',
-        'thrift>=0.11.0,<0.12.0'
     ],
     extras_require={
         "ODBC":  ['pyodbc>=4.0.30'],
+        "PyHive":  [
+            'PyHive[hive]>=0.6.0,<0.7.0',
+            'thrift>=0.11.0,<0.12.0',
+        ],
     }
 )


### PR DESCRIPTION
resolves #109 

### Description

- [`sasl`](https://github.com/cloudera/python-sasl) is an older package, not regularly maintained, and it's been bricking installs on a number of different systems
- It's a requirement of `PyHive[hive]`, which is used for `thrift` and `http` connection methods.
- If a user wants to use the `odbc` connection method, that doesn't require `PyHive` at all. Today, inability to install `sasl` prevents them from being able to use the plugin.
- This PR moves `PyHive` to be an extra requirement, rather than primary one
    - Pro: easier for ODBC users
    - Con: breaking change for existing users, who will need to replace `pip install dbt-spark` with `pip install dbt-spark[PyHive]`
    - Neutral: moves `thrift` to be an extra as well, since it's only needed by the same connection types

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 