### PR TITLE
Handle case of 0 connect retries better for HTTP Spark Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 ### Under the hood
 - Add changelog, issue templates ([#119](https://github.com/fishtown-analytics/dbt-spark/pull/119), [#120](https://github.com/fishtown-analytics/dbt-spark/pull/120))
 
+### Fixes
+- Handle case of 0 retries better for HTTP Spark Connections ([#132](https://github.com/fishtown-analytics/dbt-spark/pull/132))
+
+### Contributors
+- [@danielvdende](https://github.com/danielvdende) ([#132](https://github.com/fishtown-analytics/dbt-spark/pull/132))
+
 ## dbt-spark 0.18.1.1 (November 13, 2020)
 
 ### Fixes

--- a/dbt/adapters/spark/connections.py
+++ b/dbt/adapters/spark/connections.py
@@ -401,7 +401,7 @@ class SparkConnectionManager(SQLConnectionManager):
                         msg += ', is your token valid?'
                     raise dbt.exceptions.FailedToConnectException(msg) from e
                 retryable_message = _is_retryable_error(e)
-                if retryable_message:
+                if retryable_message and creds.connect_retries > 0:
                     msg = (
                         f"Warning: {retryable_message}\n\tRetrying in "
                         f"{creds.connect_timeout} seconds "


### PR DESCRIPTION
resolves #131

### Description

With a default of 0 connect_retries, confusing log messages show up. (see example below)

```bash
Running with dbt=0.18.1
Found 5 models, 12 tests, 0 snapshots, 0 analyses, 158 macros, 0 operations, 0 seed files, 3 sources

Warning: TEMPORARILY_UNAVAILABLE: Cluster <my-cluster-name> is temporarily unavailable. The current cluster state is Terminated. Please retry your request after 30 seconds.
        Retrying in 10 seconds (0 of 0)
Encountered an error:
Runtime Error
  Runtime Error
    TEMPORARILY_UNAVAILABLE: Cluster <my-cluster-name> is temporarily unavailable. The current cluster state is Terminated. Please retry your request after 30 seconds.
```
We encountered this while working with Databricks, where we had a cluster that had not been started yet.
The logs suggest that a retry is going to be carried out, but it isn't (because the retry count defaults to 0). Also, a sleep is carried out, even if no retries are to happen. This check prevents this from happening.


### Checklist
 - [ x ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ x ] I have run this code in development and it appears to resolve the stated issue
 - [ x ] This PR includes tests, or tests are not required/relevant for this PR
 - [ x ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 