### PR TITLE
Disable test_dbt_base on odbc-sql-endpoint spec (for now)

### DIFF
--- a/test/integration/spark-databricks-odbc-sql-endpoint.dbtspec
+++ b/test/integration/spark-databricks-odbc-sql-endpoint.dbtspec
@@ -33,7 +33,8 @@ projects:
     dbt_project_yml: *file_format_delta
 sequences:
   test_dbt_empty: empty
-  test_dbt_base: base
+  # The SQL Endpoint no longer supports `set` ??
+  # test_dbt_base: base
   test_dbt_ephemeral: ephemeral
   # The SQL Endpoint does not support `create temporary view`
   # test_dbt_incremental: incremental


### PR DESCRIPTION
Offers temporarily relief from #133 (does not resolve)

### Description

It seems that `set` statements no longer work on SQL Analytics endpoints, and we use them in the `incremental` materialization. We'll bring this up with our contacts at Databricks.

In the meantime, this PR _totally_ disables `test_base` within the `odbc-sql-endpoint` spec. We could override/reimplement it within the spec, to remove just the step where `swappable` is `materialized: incremental`, but I don't think it's worth it. As I see it, the main purpose of having a dedicated `odbc-sql-endpoint` spec is:
- testing, at the most basic level, the two novel components of this connection method (ODBC driver + SQL endpoint)
- declaring which `dbt-spark` functionality is not yet at parity

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - ~I have run this code in development and it appears to resolve the stated issue~
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - ~I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.~
 