### PR TITLE
SQL Endpoint only supports `merge` incremental strategy [and still doesn't yet]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 ## dbt-spark 0.19.0 (Release TBD)
 
+### Under the hood
+- Disable `incremental_strategy: insert_overwrite` when connecting to Databricks SQL Endpoint, as it does not support `set` statements for Spark configs ([#133](https://github.com/fishtown-analytics/dbt-spark/pull/133), [#138](https://github.com/fishtown-analytics/dbt-spark/pull/138))
+
+## dbt-spark 0.19.0-rc1 (January 8, 2021)
+
 ### Breaking changes
 - Users of the `http` and `thrift` connection methods need to install extra requirements: `pip install dbt-spark[PyHive]` ([#109](https://github.com/fishtown-analytics/dbt-spark/pull/109), [#126](https://github.com/fishtown-analytics/dbt-spark/pull/126))
 
 ### Under the hood
-- Enable `CREATE OR REPLACE` support when using Delta. Instead of dropping and recreating the table, it will keep the existing table, and add a new version as supported by Delta. This will ensure that the table stays available when running the pipeline, and you can track the history.
-- Add changelog, issue templates ([#119](https://github.com/fishtown-analytics/dbt-spark/pull/119), [#120](https://github.com/fishtown-analytics/dbt-spark/pull/120))
+- Enable `CREATE OR REPLACE` support when using Delta. Instead of dropping and recreating the table, it will keep the existing table, and add a new version as supported by Delta. This will ensure that the table stays available when running the pipeline, and you can track the history ([#124](https://github.com/fishtown-analytics/dbt-spark/pull/124), [#125](https://github.com/fishtown-analytics/dbt-spark/pull/120))
+- Add changelog, issue templates ([#125](https://github.com/fishtown-analytics/dbt-spark/pull/119), [#120](https://github.com/fishtown-analytics/dbt-spark/pull/120))
 
 ### Fixes
-- Handle case of 0 retries better for HTTP Spark Connections ([#132](https://github.com/fishtown-analytics/dbt-spark/pull/132))
+- Handle case of 0 retries better for HTTP Spark Connections ([#131](https://github.com/fishtown-analytics/dbt-spark/pull/131), [#132](https://github.com/fishtown-analytics/dbt-spark/pull/132))
 
 ### Contributors
 - [@danielvdende](https://github.com/danielvdende) ([#132](https://github.com/fishtown-analytics/dbt-spark/pull/132))

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -109,7 +109,8 @@
     {% do dbt_spark_validate_merge(file_format) %}
   {% endif %}
 
-  {%- if strategy == 'insert_overwrite' -%}
+  {%- if strategy == 'insert_overwrite' and file_format != 'delta' -%}
+  {# these should only be necessary for `insert overwrite` on non-delta formats #}
 
     {% if config.get('partition_by') %}
       {% call statement() %}

--- a/dbt/include/spark/macros/materializations/incremental.sql
+++ b/dbt/include/spark/macros/materializations/incremental.sql
@@ -40,8 +40,8 @@
   
   {% set invalid_insert_overwrite_msg -%}
     Invalid incremental strategy provided: {{ strategy }}
-    You cannot use this strategy when connecting to a SQL Endpoint
-    Use `merge` with a `unique_key` and file_format = `delta` instead
+    You can only choose this strategy when file_format is set to 'delta'
+    if connecting to a SQL Endpoint 
   {%- endset %}
 
   {% if strategy not in ['merge', 'insert_overwrite'] %}
@@ -50,7 +50,7 @@
     {% if strategy == 'merge' and file_format != 'delta' %}
       {% do exceptions.raise_compiler_error(invalid_merge_msg) %}
     {% endif %}
-    {% if strategy == 'insert_overwrite' and target.endpoint %}
+    {% if strategy == 'insert_overwrite' and file_format != 'delta' and target.endpoint %}
       {% do exceptions.raise_compiler_error(invalid_insert_overwrite_msg) %}
     {% endif %}
   {% endif %}

--- a/test/integration/spark-databricks-odbc-sql-endpoint.dbtspec
+++ b/test/integration/spark-databricks-odbc-sql-endpoint.dbtspec
@@ -10,16 +10,18 @@ target:
   connect_retries: 5
   connect_timeout: 60
 projects:
-  - overrides: incremental
-    paths:
-      "models/incremental.sql":
-        materialized: incremental
-        body: "select * from {{ source('raw', 'seed') }}"
-    facts:
-      base:
-        rowcount: 10
-      added:
-        rowcount: 20
+#  - overrides: incremental
+#    paths:
+#      "models/incremental.sql":
+#        materialized: incremental
+#        file_format: delta
+#        incremental_strategy: merge
+#        body: "select * from {{ source('raw', 'seed') }}"
+#    facts:
+#      base:
+#        rowcount: 10
+#      added:
+#        rowcount: 20
   - overrides: snapshot_strategy_check_cols
     dbt_project_yml: &file_format_delta
       # we're going to UPDATE the seed tables as part of testing, so we must make them delta format
@@ -33,10 +35,10 @@ projects:
     dbt_project_yml: *file_format_delta
 sequences:
   test_dbt_empty: empty
-  # The SQL Endpoint no longer supports `set` ??
-  # test_dbt_base: base
   test_dbt_ephemeral: ephemeral
-  # The SQL Endpoint does not support `create temporary view`
+  # The SQL Endpoint does not yet support `create temporary view`
+  # As such, incremental models are currently unsupported
+  # test_dbt_base: base
   # test_dbt_incremental: incremental
   test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
   test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols


### PR DESCRIPTION
resolves #133

### Disable `insert_overwrite` for endpoint

In order for the `insert_overwrite` incremental strategy to work as expected, we set two properties:
- If the table is partitioned, we set `set spark.sql.sources.partitionOverwriteMode = DYNAMIC` so that Spark will dynamically determine which partitions have new data, and then replace only those, leaving in place any without new data. If the table is not partitioned, Spark will replace the entire table, equivalent to an atomic `truncate` + `insert`.
- Regardless, we set `spark.sql.hive.convertMetastoreParquet = false` ([docs](https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#hive-metastore-parquet-table-conversion)): I honestly don't remember the exact reasons, but this has been here since the earliest days of incremental models in dbt-spark (c13b20a216e4b8e914ddad8c385085b5b980d025)

Several weeks ago, we found that the new SQL Endpoints started returning errors when dbt tried to run `set` statements. Following discussion with our contacts at Databricks, we found out that this support was never intended:

> - The SQL analytics [endpoints] especially do not support setting the spark config properties (they do have a very minimal set of whitelisted properties that one can set).

This PR therefore:
- Conditions those `set` statements to run IFF the incremental strategy is `insert_overwrite`
- Raises a compilation error if the user tries to run an incremental model with `insert_overwrite` strategy on the SQL Endpoint:
```
 Compilation Error in model incremental (models/incremental.sql)
   Invalid incremental strategy provided: insert_overwrite
       You cannot use this strategy when connecting to a SQL Endpoint
       Use `merge` with a `unique_key` and file_format = `delta` instead

   > in macro dbt_spark_validate_get_incremental_strategy (macros/materializations/incremental.sql)
   > called by macro materialization_incremental_spark (macros/materializations/incremental.sql)
   > called by model incremental (models/incremental.sql)
```
 
This may feel a bit silly, given that `insert_overwrite` is the default, and `merge` requires two additional configs. Should we change the defaults depending on the connection type? i.e. Default to `incremental_strategy: merge` and `file_format: delta` (instead of `parquet`) if the user has an ODBC connection to Databricks.

### Whereas `merge` should work... soon

There's one other issue that currently prevents incremental models, even `merge`-strategy ones, from running on the SQL Analytics endpoint: `create temp view` is not yet supported. In that case, crucially, Databricks intends to eventually support it:

> We are still working on getting the temporary view support for SQL analytics and will provide an update shortly.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 