### PR TITLE
Capture hard deleted records in snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-spark 0.19.0 (Release TBD)
 
+### Fixes
+- Capture hard-deleted records in snapshot merge, when `invalidate_hard_deletes` config is set ([#109](https://github.com/fishtown-analytics/dbt-spark/pull/143), [#126](https://github.com/fishtown-analytics/dbt-spark/pull/144))
+
+## dbt-spark 0.19.0rc1 (January 8, 2021)
+
 ### Breaking changes
 - Users of the `http` and `thrift` connection methods need to install extra requirements: `pip install dbt-spark[PyHive]` ([#109](https://github.com/fishtown-analytics/dbt-spark/pull/109), [#126](https://github.com/fishtown-analytics/dbt-spark/pull/126))
 

--- a/dbt/include/spark/macros/materializations/snapshot.sql
+++ b/dbt/include/spark/macros/materializations/snapshot.sql
@@ -19,7 +19,7 @@
     on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id
     when matched
      and DBT_INTERNAL_DEST.dbt_valid_to is null
-     and DBT_INTERNAL_SOURCE.dbt_change_type = 'update'
+     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
         then update
         set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to
 


### PR DESCRIPTION
Resolved #143

Alternative: We stop overriding the default merge macros. Databricks' implementation is strictly better because it lets us use `update *` + `insert *`, but the default ones should still work, and it would avoid situations like this one where we miss an upstream improvement.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 