### PR TITLE
Cast table_owner to str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt next
+
+### Fixes
+
+- Cast `table_owner` to string to avoid errors generating docs ([#159](https://github.com/fishtown-analytics/dbt-spark/pull/159))
+
 ## dbt-spark 0.19.1 (Release TBD)
 
 ## dbt-spark 0.19.1b2 (February 26, 2021)

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -180,7 +180,7 @@ class SparkAdapter(SQLAdapter):
             table_schema=relation.schema,
             table_name=relation.name,
             table_type=relation.type,
-            table_owner=metadata.get(KEY_TABLE_OWNER),
+            table_owner=str(metadata.get(KEY_TABLE_OWNER)),
             table_stats=table_stats,
             column=column['col_name'],
             column_index=idx,

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -332,9 +332,7 @@ class TestSparkAdapter(unittest.TestCase):
         rows = SparkAdapter(config).parse_describe_extended(
             relation, input_cols)
 
-        self.assertEqual(rows[0].to_column_dict()['table_owner'], '1234')
-        self.assertEqual(rows[1].to_column_dict()['table_owner'], '1234')
-        self.assertEqual(rows[2].to_column_dict()['table_owner'], '1234')
+        self.assertEqual(rows[0].to_column_dict().get('table_owner'), '1234')
 
     def test_parse_relation_with_statistics(self):
         self.maxDiff = None

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -322,7 +322,7 @@ class TestSparkAdapter(unittest.TestCase):
         plain_rows = [
             ('col1', 'decimal(22,0)'),
             ('# Detailed Table Information', None),
-            ('Owner', 1234),
+            ('Owner', 1234)
         ]
 
         input_cols = [Row(keys=['col_name', 'data_type'], values=r)


### PR DESCRIPTION
resolves #158 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->


### Description

Having an integer table_owner causes problems with dbt docs generate, so we make sure to always cast this to a String.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 