### PR TITLE
Parse information returned by list_relations_without_caching macro to speed up catalog generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 - Cast `table_owner` to string to avoid errors generating docs ([#158](https://github.com/fishtown-analytics/dbt-spark/pull/158), [#159](https://github.com/fishtown-analytics/dbt-spark/pull/159))
 
+### Under the hood
+
+- Parse information returned by `list_relations_without_caching` macro to speed up catalog generation ([#93](https://github.com/fishtown-analytics/dbt-spark/issues/93), [#160](https://github.com/fishtown-analytics/dbt-spark/pull/160))
+
 ### Contributors
 - [@friendofasquid](https://github.com/friendofasquid) ([#159](https://github.com/fishtown-analytics/dbt-spark/pull/159))
+- [@franloza](https://github.com/franloza) ([#160](https://github.com/fishtown-analytics/dbt-spark/pull/160))
+
 
 ## dbt-spark 0.19.1 (Release TBD)
 

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -242,11 +242,19 @@ class SparkAdapter(SQLAdapter):
     def _get_columns_for_catalog(
         self, relation: SparkRelation
     ) -> Iterable[Dict[str, Any]]:
-        columns = self.get_columns_from_information(relation)
+        if relation and relation.information is not None:
+            columns = self.get_columns_from_information(relation)
+            owner = None
+        else:
+            properties = self.get_properties(relation)
+            columns = self.get_columns_in_relation(relation)
+            owner = properties.get(KEY_TABLE_OWNER)
 
         for column in columns:
             # convert SparkColumns into catalog dicts
             as_dict = column.to_column_dict()
+            if owner:
+                column.table_owner = owner
             as_dict['column_name'] = as_dict.pop('column', None)
             as_dict['column_type'] = as_dict.pop('dtype')
             as_dict['table_database'] = None

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -224,7 +224,7 @@ class SparkAdapter(SQLAdapter):
         matches = re.finditer(
             self.INFORMATION_COLUMNS_REGEX, relation.information)
         columns = []
-        for match_num, match in enumerate(matches, start=1):
+        for match_num, match in enumerate(matches):
             column_name, column_type, nullable = match.groups()
             column = SparkColumn(
                 table_database=None,

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -212,10 +212,10 @@ class SparkAdapter(SQLAdapter):
             rows: List[agate.Row] = super().get_columns_in_relation(relation)
             columns = self.parse_describe_extended(relation, rows)
         else:
-            columns = self.get_columns_from_information(cached_relation)
+            columns = self.parse_columns_from_information(cached_relation)
         return columns
 
-    def get_columns_from_information(
+    def parse_columns_from_information(
             self, relation: SparkRelation
     ) -> List[SparkColumn]:
         owner_match = re.findall(
@@ -242,7 +242,7 @@ class SparkAdapter(SQLAdapter):
     def _get_columns_for_catalog(
         self, relation: SparkRelation
     ) -> Iterable[Dict[str, Any]]:
-        columns = self.get_columns_from_information(relation)
+        columns = self.parse_columns_from_information(relation)
 
         for column in columns:
             # convert SparkColumns into catalog dicts

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -64,7 +64,8 @@ class SparkAdapter(SQLAdapter):
     INFORMATION_COLUMNS_REGEX = re.compile(
         r"\|-- (.*): (.*) \(nullable = (.*)\b", re.MULTILINE)
     INFORMATION_OWNER_REGEX = re.compile(r"^Owner: (.*)$", re.MULTILINE)
-    INFORMATION_STATISTICS_REGEX = re.compile(r"^Statistics: (.*)$", re.MULTILINE)
+    INFORMATION_STATISTICS_REGEX = re.compile(
+        r"^Statistics: (.*)$", re.MULTILINE)
 
     Relation = SparkRelation
     Column = SparkColumn

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -1,3 +1,4 @@
+import re
 from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any, Union, Iterable
@@ -60,6 +61,8 @@ class SparkAdapter(SQLAdapter):
         'stats:rows:description',
         'stats:rows:include',
     )
+    INFORMATION_COLUMNS_REGEX = re.compile(r"\|-- (.*): (.*) \(nullable = (.*)\b", re.MULTILINE)
+    INFORMATION_OWNER_REGEX = re.compile(r"^Owner: (.*)$", re.MULTILINE)
 
     Relation = SparkRelation
     Column = SparkColumn
@@ -139,7 +142,8 @@ class SparkAdapter(SQLAdapter):
                 schema=_schema,
                 identifier=name,
                 type=rel_type,
-                is_delta=is_delta
+                information=information,
+                is_delta=is_delta,
             )
             relations.append(relation)
 
@@ -197,19 +201,43 @@ class SparkAdapter(SQLAdapter):
         return pos
 
     def get_columns_in_relation(self, relation: Relation) -> List[SparkColumn]:
-        rows: List[agate.Row] = super().get_columns_in_relation(relation)
-        return self.parse_describe_extended(relation, rows)
+        cached_relations = self.cache.get_relations(relation.database, relation.schema)
+        cached_relation = next((cached_relation
+                                for cached_relation in cached_relations
+                                if str(cached_relation) == str(relation)), None)
+        if cached_relations is None:
+            rows: List[agate.Row] = super().get_columns_in_relation(relation)
+            columns = self.parse_describe_extended(relation, rows)
+        else:
+            columns = self.get_columns_from_information(cached_relation)
+        return columns
+
+    def get_columns_from_information(self, relation: SparkRelation) -> List[SparkColumn]:
+        owner_match = re.findall(self.INFORMATION_OWNER_REGEX, relation.information)
+        owner = owner_match[0] if owner_match else None
+        matches = re.finditer(self.INFORMATION_COLUMNS_REGEX, relation.information)
+        columns = []
+        for match_num, match in enumerate(matches, start=1):
+            column_name, column_type, nullable = match.groups()
+            column = SparkColumn(
+                table_database=None,
+                table_schema=relation.schema,
+                table_name=relation.table,
+                table_type=relation.type,
+                column_index=match_num,
+                table_owner=owner,
+                column=column_name,
+                dtype=column_type
+            )
+            columns.append(column)
+        return columns
 
     def _get_columns_for_catalog(
         self, relation: SparkRelation
     ) -> Iterable[Dict[str, Any]]:
-        properties = self.get_properties(relation)
-        columns = self.get_columns_in_relation(relation)
-        owner = properties.get(KEY_TABLE_OWNER)
+        columns = self.get_columns_from_information(relation)
 
         for column in columns:
-            if owner:
-                column.table_owner = owner
             # convert SparkColumns into catalog dicts
             as_dict = column.to_column_dict()
             as_dict['column_name'] = as_dict.pop('column', None)

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -208,7 +208,7 @@ class SparkAdapter(SQLAdapter):
                                 for cached_relation in cached_relations
                                 if str(cached_relation) == str(relation)),
                                None)
-        if cached_relations is None:
+        if cached_relation is None:
             rows: List[agate.Row] = super().get_columns_in_relation(relation)
             columns = self.parse_describe_extended(relation, rows)
         else:
@@ -242,19 +242,11 @@ class SparkAdapter(SQLAdapter):
     def _get_columns_for_catalog(
         self, relation: SparkRelation
     ) -> Iterable[Dict[str, Any]]:
-        if relation and relation.information is not None:
-            columns = self.get_columns_from_information(relation)
-            owner = None
-        else:
-            properties = self.get_properties(relation)
-            columns = self.get_columns_in_relation(relation)
-            owner = properties.get(KEY_TABLE_OWNER)
+        columns = self.get_columns_from_information(relation)
 
         for column in columns:
             # convert SparkColumns into catalog dicts
             as_dict = column.to_column_dict()
-            if owner:
-                column.table_owner = owner
             as_dict['column_name'] = as_dict.pop('column', None)
             as_dict['column_type'] = as_dict.pop('dtype')
             as_dict['table_database'] = None

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -61,7 +61,8 @@ class SparkAdapter(SQLAdapter):
         'stats:rows:description',
         'stats:rows:include',
     )
-    INFORMATION_COLUMNS_REGEX = re.compile(r"\|-- (.*): (.*) \(nullable = (.*)\b", re.MULTILINE)
+    INFORMATION_COLUMNS_REGEX = re.compile(
+        r"\|-- (.*): (.*) \(nullable = (.*)\b", re.MULTILINE)
     INFORMATION_OWNER_REGEX = re.compile(r"^Owner: (.*)$", re.MULTILINE)
 
     Relation = SparkRelation
@@ -201,10 +202,12 @@ class SparkAdapter(SQLAdapter):
         return pos
 
     def get_columns_in_relation(self, relation: Relation) -> List[SparkColumn]:
-        cached_relations = self.cache.get_relations(relation.database, relation.schema)
+        cached_relations = self.cache.get_relations(
+            relation.database, relation.schema)
         cached_relation = next((cached_relation
                                 for cached_relation in cached_relations
-                                if str(cached_relation) == str(relation)), None)
+                                if str(cached_relation) == str(relation)),
+                               None)
         if cached_relations is None:
             rows: List[agate.Row] = super().get_columns_in_relation(relation)
             columns = self.parse_describe_extended(relation, rows)
@@ -212,10 +215,14 @@ class SparkAdapter(SQLAdapter):
             columns = self.get_columns_from_information(cached_relation)
         return columns
 
-    def get_columns_from_information(self, relation: SparkRelation) -> List[SparkColumn]:
-        owner_match = re.findall(self.INFORMATION_OWNER_REGEX, relation.information)
+    def get_columns_from_information(
+            self, relation: SparkRelation
+    ) -> List[SparkColumn]:
+        owner_match = re.findall(
+            self.INFORMATION_OWNER_REGEX, relation.information)
         owner = owner_match[0] if owner_match else None
-        matches = re.finditer(self.INFORMATION_COLUMNS_REGEX, relation.information)
+        matches = re.finditer(
+            self.INFORMATION_COLUMNS_REGEX, relation.information)
         columns = []
         for match_num, match in enumerate(matches, start=1):
             column_name, column_type, nullable = match.groups()

--- a/dbt/adapters/spark/relation.py
+++ b/dbt/adapters/spark/relation.py
@@ -26,6 +26,7 @@ class SparkRelation(BaseRelation):
     include_policy: SparkIncludePolicy = SparkIncludePolicy()
     quote_character: str = '`'
     is_delta: Optional[bool] = None
+    information: str = None
 
     def __post_init__(self):
         if self.database != self.schema and self.database:

--- a/test/unit/test_column.py
+++ b/test/unit/test_column.py
@@ -1,0 +1,38 @@
+import unittest
+
+from dbt.adapters.spark import SparkColumn
+
+
+class TestSparkColumn(unittest.TestCase):
+
+    def test_convert_table_stats_with_no_statistics(self):
+        self.assertDictEqual(
+            SparkColumn.convert_table_stats(None),
+            {}
+        )
+
+    def test_convert_table_stats_with_bytes(self):
+        self.assertDictEqual(
+            SparkColumn.convert_table_stats("123456789 bytes"),
+            {
+                'stats:bytes:description': '',
+                'stats:bytes:include': True,
+                'stats:bytes:label': 'bytes',
+                'stats:bytes:value': 123456789
+            }
+        )
+
+    def test_convert_table_stats_with_bytes_and_rows(self):
+        self.assertDictEqual(
+            SparkColumn.convert_table_stats("1234567890 bytes, 12345678 rows"),
+            {
+                'stats:bytes:description': '',
+                'stats:bytes:include': True,
+                'stats:bytes:label': 'bytes',
+                'stats:bytes:value': 1234567890,
+                'stats:rows:description': '',
+                'stats:rows:include': True,
+                'stats:rows:label': 'rows',
+                'stats:rows:value': 12345678
+            }
+        )


### PR DESCRIPTION
Resolves https://github.com/fishtown-analytics/dbt-spark/issues/93

### Description

Use regular expressions to parse the information retrieved by `show table extended in [schema] like '*'`. In this way, it's no longer necessary to run `show tblproperties` and `describe extended`  on every single relation.


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 