### PR TITLE
Support persist_docs for column descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt next
 
+### Features
+- Add support for column comment ([#170](https://github.com/fishtown-analytics/dbt-spark/pull/170))
+
 ### Fixes
 
 - Cast `table_owner` to string to avoid errors generating docs ([#158](https://github.com/fishtown-analytics/dbt-spark/pull/158), [#159](https://github.com/fishtown-analytics/dbt-spark/pull/159))
@@ -13,6 +16,7 @@
 - [@friendofasquid](https://github.com/friendofasquid) ([#159](https://github.com/fishtown-analytics/dbt-spark/pull/159))
 - [@franloza](https://github.com/franloza) ([#160](https://github.com/fishtown-analytics/dbt-spark/pull/160))
 - [@Fokko](https://github.com/Fokko) ([#165](https://github.com/fishtown-analytics/dbt-spark/pull/165))
+- [@cristianoperez](https://github.com/cristianoperez) ([#170](https://github.com/fishtown-analytics/dbt-spark/pull/170))
 
 ## dbt-spark 0.19.1 (Release TBD)
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The following configurations can be supplied to models run with the dbt-spark pl
 | clustered_by         | Each partition in the created table will be split into a fixed number of buckets by the specified columns.                                                  | Optional                                | `cluster_1`          |
 | buckets              | The number of buckets to create while clustering                                                                                                            | Required if `clustered_by` is specified | `8`                  |
 | incremental_strategy | The strategy to use for incremental models (`append`, `insert_overwrite`, or `merge`). | Optional (default: `append`)  | `merge`              |
-| persist_docs         | Whether dbt should include the model description as a table `comment`                                                                                       | Optional                                | `{'relation': true}` |
+| persist_docs         | Whether dbt should include the model description as a table or column `comment`                                                                                       | Optional                                | `{'relation': true, 'columns': true}` |
 
 
 **Incremental Models**

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -162,3 +162,16 @@
 {% macro spark__generate_database_name(custom_database_name=none, node=none) -%}
   {% do return(None) %}
 {%- endmacro %}
+
+{% macro spark__alter_column_comment(relation, column_dict) %}
+  {% if config.get('file_format', validator=validation.any[basestring]) == 'delta' %}
+    {% for column_name in column_dict %}
+      {% set comment = column_dict[column_name]['description'] %}
+      {% set comment_query %}
+        ALTER TABLE {{ relation }} ALTER COLUMN {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} COMMENT '{{ comment }}';
+      {% endset %}
+      {% do run_query(comment_query) %}
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -168,7 +168,7 @@
     {% for column_name in column_dict %}
       {% set comment = column_dict[column_name]['description'] %}
       {% set comment_query %}
-        ALTER TABLE {{ relation }} ALTER COLUMN {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} COMMENT '{{ comment }}';
+        alter table {{ relation }} change column {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} comment '{{ comment }}';
       {% endset %}
       {% do run_query(comment_query) %}
     {% endfor %}


### PR DESCRIPTION
resolves #84

### Description

Adds support for column descriptions when its in Delta format and `persist_docs = {'columns': true}`


### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 