### PR TITLE
Add options clause to create table macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt next
 
+### Features
+- Allow setting table `OPTIONS` using `config` ([#171](https://github.com/fishtown-analytics/dbt-spark/pull/171))
+
 ### Fixes
 
 - Cast `table_owner` to string to avoid errors generating docs ([#158](https://github.com/fishtown-analytics/dbt-spark/pull/158), [#159](https://github.com/fishtown-analytics/dbt-spark/pull/159))
@@ -13,6 +16,7 @@
 - [@friendofasquid](https://github.com/friendofasquid) ([#159](https://github.com/fishtown-analytics/dbt-spark/pull/159))
 - [@franloza](https://github.com/franloza) ([#160](https://github.com/fishtown-analytics/dbt-spark/pull/160))
 - [@Fokko](https://github.com/Fokko) ([#165](https://github.com/fishtown-analytics/dbt-spark/pull/165))
+- [@JCZuurmond](https://github.com/JCZuurmond) ([#171](https://github.com/fishtown-analytics/dbt-spark/pull/171))
 
 ## dbt-spark 0.19.1 (Release TBD)
 

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -36,6 +36,7 @@ class SparkConfig(AdapterConfig):
     partition_by: Optional[Union[List[str], str]] = None
     clustered_by: Optional[Union[List[str], str]] = None
     buckets: Optional[int] = None
+    options: Optional[Dict[str, str]] = None
 
 
 class SparkAdapter(SQLAdapter):

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -13,6 +13,16 @@
   {%- endif %}
 {%- endmacro -%}
 
+{% macro options_clause() -%}
+  {%- set options = config.get('options') -%}
+  {%- if options is not none %}
+    OPTIONS (
+      {%- for option in options -%}
+      {{ option }} "{{ options[option] }}" {% if not loop.last %}, {% endif %}
+      {%- endfor %}
+    )
+  {%- endif %}
+{%- endmacro -%}
 
 {% macro comment_clause() %}
   {%- set raw_persist_docs = config.get('persist_docs', {}) -%}

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -93,6 +93,7 @@
       create table {{ relation }}
     {% endif %}
     {{ file_format_clause() }}
+    {{ options_clause() }}
     {{ partition_cols(label="partitioned by") }}
     {{ clustered_cols(label="clustered by") }}
     {{ location_clause() }}

--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -16,7 +16,7 @@
 {% macro options_clause() -%}
   {%- set options = config.get('options') -%}
   {%- if options is not none %}
-    OPTIONS (
+    options (
       {%- for option in options -%}
       {{ option }} "{{ options[option] }}" {% if not loop.last %}, {% endif %}
       {%- endfor %}

--- a/test/unit/test_macros.py
+++ b/test/unit/test_macros.py
@@ -46,6 +46,7 @@ class TestSparkMacros(unittest.TestCase):
     def test_macros_create_table_as_options(self):
         template = self.__get_template('adapters.sql')
 
+        self.config['file_format'] = 'delta'
         self.config['options'] = {"compression": "gzip"}
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
         self.assertEqual(sql, "create or replace table options (compression 'gzip') my_table using delta as select 1")

--- a/test/unit/test_macros.py
+++ b/test/unit/test_macros.py
@@ -49,7 +49,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['file_format'] = 'delta'
         self.config['options'] = {"compression": "gzip"}
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, 'create table my_table options (compression "gzip" ) using delta as select 1')
+        self.assertEqual(sql, 'create or replace table my_table using delta options (compression "gzip" ) as select 1')
 
     def test_macros_create_table_as_partition(self):
         template = self.__get_template('adapters.sql')

--- a/test/unit/test_macros.py
+++ b/test/unit/test_macros.py
@@ -43,6 +43,13 @@ class TestSparkMacros(unittest.TestCase):
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
         self.assertEqual(sql, "create or replace table my_table using delta as select 1")
 
+    def test_macros_create_table_as_options(self):
+        template = self.__get_template('adapters.sql')
+
+        self.config['options'] = {"compression": "gzip"}
+        sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
+        self.assertEqual(sql, "create or replace table options (compression 'gzip') my_table using delta as select 1")
+
     def test_macros_create_table_as_partition(self):
         template = self.__get_template('adapters.sql')
 

--- a/test/unit/test_macros.py
+++ b/test/unit/test_macros.py
@@ -49,7 +49,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['file_format'] = 'delta'
         self.config['options'] = {"compression": "gzip"}
         sql = self.__run_macro(template, 'spark__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create or replace table options (compression 'gzip') my_table using delta as select 1")
+        self.assertEqual(sql, 'create table my_table options (compression "gzip" ) using delta as select 1')
 
     def test_macros_create_table_as_partition(self):
         template = self.__get_template('adapters.sql')


### PR DESCRIPTION
resolves #147 

### Description

Adds an option clause macro which allows for adding options to a table via the config:

```jinja
{{
  config(
    materialized='table',
    file_format='jdbc',
    options={
      'dbtable': 'my_table',
      'url': 'jdbc:sqlserver://${spark.serverName}:1433;databaseName=database;',
      'user': '${spark.adminUsername}',
      'password': '${spark.adminPassword}'
    }
  )
}}
```

Heavily inspired on #148. @friendofasquid : I went ahead, implemented a solution based on the examples you created, here to contribute back.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 