### PR TITLE
Mv17420 csv seed truncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## dbt-spark 0.20.1 (June 24, 2021)
+
+### Features
+
+### Fixes
+- Add Spark [insert overwrite](http://spark.apache.org/docs/latest/sql-ref-syntax-dml-insert-overwrite-table.html) to csv seeds command to overwrite the existing data in the seed tables. As explained in [issue 112](https://github.com/fishtown-analytics/dbt-spark/issues/112), the current seed command in dbt-spark is appending to existing seeded tables.
+
+### Under the hood
+
+### Contributors
+- [@mv1742](https://github.com/mv1742) ([#159](https://github.com/mv1742/)
+
 ## dbt-spark 0.20.0 (Release TBD)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-- Add Spark [insert overwrite](http://spark.apache.org/docs/latest/sql-ref-syntax-dml-insert-overwrite-table.html) to csv seeds command to overwrite the existing data in the seed tables. As explained in [issue 112](https://github.com/fishtown-analytics/dbt-spark/issues/112), the current seed command in dbt-spark is appending to existing seeded tables.
+- dbt seed command fixed with expected behavior from dbt global project to [truncate table](https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-ddl-truncate-table.html) in order remove all rows from the existing seed tables and replace values. As explained in [issue 112](https://github.com/fishtown-analytics/dbt-spark/issues/112), the current seed command in dbt-spark appends to existing seeded tables instead overwriting.
 
 ### Contributors
 - [@mv1742](https://github.com/mv1742) ([#159](https://github.com/mv1742/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
-## dbt-spark 0.20.1 (June 24, 2021)
+## dbt-spark 0.20.1 (June 22, 2021)
 
 ### Features
 
 ### Fixes
 - Add Spark [insert overwrite](http://spark.apache.org/docs/latest/sql-ref-syntax-dml-insert-overwrite-table.html) to csv seeds command to overwrite the existing data in the seed tables. As explained in [issue 112](https://github.com/fishtown-analytics/dbt-spark/issues/112), the current seed command in dbt-spark is appending to existing seeded tables.
-
-### Under the hood
 
 ### Contributors
 - [@mv1742](https://github.com/mv1742) ([#159](https://github.com/mv1742/)

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -82,6 +82,7 @@
                                                type='table') -%}
   {%- set agate_table = load_agate_table() -%}
   {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}
+
   {{ run_hooks(pre_hooks) }}
 
   -- build model

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -1,7 +1,7 @@
 {% macro spark__load_csv_rows(model, agate_table) %}
     {% set batch_size = 1000 %}
     {% set column_override = model['config'].get('column_types', {}) %}
-    
+
     {% set statements = [] %}
 
     {% for chunk in agate_table.rows | batch(batch_size) %}
@@ -12,7 +12,7 @@
         {% endfor %}
 
         {% set sql %}
-            insert {{ "overwrite" if loop.first else "into" }} {{ this.render() }} values
+            insert overwrite {{ this.render() }} values
             {% for row in chunk -%}
                 ({%- for col_name in agate_table.column_names -%}
                     {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -36,10 +36,14 @@
 {% endmacro %}
 
 {% macro spark__reset_csv_table(model, full_refresh, old_relation, agate_table) %}
-    {% if old_relation %}
+    {% set sql = "" %}
+    {% if full_refresh %}
         {{ adapter.drop_relation(old_relation) }}
+        {% set sql = create_csv_table(model, agate_table) %}
+    {% else %}
+        {{ adapter.truncate_relation(old_relation) }}
+        {% set sql = "truncate table " ~ old_relation %}
     {% endif %}
-    {% set sql = create_csv_table(model, agate_table) %}
     {{ return(sql) }}
 {% endmacro %}
 

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -12,7 +12,7 @@
         {% endfor %}
 
         {% set sql %}
-            insert overwrite {{ this.render() }} values
+            insert into {{ this.render() }} values
             {% for row in chunk -%}
                 ({%- for col_name in agate_table.column_names -%}
                     {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -36,14 +36,12 @@
 {% endmacro %}
 
 {% macro spark__reset_csv_table(model, full_refresh, old_relation, agate_table) %}
-    {% set sql = "" %}
-    {% if full_refresh %}
-        {{ adapter.drop_relation(old_relation) }}
-        {% set sql = create_csv_table(model, agate_table) %}
-    {% else %}
+    {% if old_relation %}
         {{ adapter.truncate_relation(old_relation) }}
         {% set sql = "truncate table " ~ old_relation %}
+        {{ return(sql) }}
     {% endif %}
+    {% set sql = create_csv_table(model, agate_table) %}
     {{ return(sql) }}
 {% endmacro %}
 
@@ -84,7 +82,6 @@
                                                type='table') -%}
   {%- set agate_table = load_agate_table() -%}
   {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}
-
   {{ run_hooks(pre_hooks) }}
 
   -- build model

--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -12,7 +12,7 @@
         {% endfor %}
 
         {% set sql %}
-            insert into {{ this.render() }} values
+            insert {{ "overwrite" if loop.first else "into" }} {{ this.render() }} values
             {% for row in chunk -%}
                 ({%- for col_name in agate_table.column_names -%}
                     {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}


### PR DESCRIPTION
resolves #112 

### Description

- dbt seed command fixed with expected behavior from dbt global project to [truncate table](https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-ddl-truncate-table.html) in order remove all rows from the existing seed tables and replace values. As explained in [issue 112](https://github.com/fishtown-analytics/dbt-spark/issues/112), the current seed command in dbt-spark appends to existing seeded tables instead overwriting.

### Checklist
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 