### PR TITLE
Add merge_update_columns config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-spark 0.20.0 (Release TBD)
 
+### Features
+
+- Add support for `merge_update_columns` config in `merge`-strategy incremental models ([#183](https://github.com/fishtown-analytics/dbt-spark/pull/183), ([#184](https://github.com/fishtown-analytics/dbt-spark/pull/184))
+
 ### Fixes
 
 - Fix column-level `persist_docs` on Delta tables, add tests ([#180](https://github.com/fishtown-analytics/dbt-spark/pull/180))

--- a/dbt/adapters/spark/impl.py
+++ b/dbt/adapters/spark/impl.py
@@ -37,6 +37,7 @@ class SparkConfig(AdapterConfig):
     clustered_by: Optional[Union[List[str], str]] = None
     buckets: Optional[int] = None
     options: Optional[Dict[str, str]] = None
+    merge_update_columns: Optional[str] = None
 
 
 class SparkAdapter(SQLAdapter):

--- a/test/custom/incremental_strategies/data/expected_partial_upsert.csv
+++ b/test/custom/incremental_strategies/data/expected_partial_upsert.csv
@@ -1,0 +1,4 @@
+id,msg,color
+1,hello,blue
+2,yo,red
+3,anyway,purple

--- a/test/custom/incremental_strategies/models_delta/merge_update_columns.sql
+++ b/test/custom/incremental_strategies/models_delta/merge_update_columns.sql
@@ -1,0 +1,22 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'merge',
+    file_format = 'delta',
+    unique_key = 'id',
+    merge_update_columns = ['msg'],
+) }}
+
+{% if not is_incremental() %}
+
+select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
+union all
+select cast(2 as bigint) as id, 'goodbye' as msg, 'red' as color
+
+{% else %}
+
+-- msg will be updated, color will be ignored
+select cast(2 as bigint) as id, 'yo' as msg, 'green' as color
+union all
+select cast(3 as bigint) as id, 'anyway' as msg, 'purple' as color
+
+{% endif %}

--- a/test/custom/incremental_strategies/test_incremental_strategies.py
+++ b/test/custom/incremental_strategies/test_incremental_strategies.py
@@ -71,6 +71,7 @@ class TestDeltaStrategies(TestIncrementalStrategies):
         self.assertTablesEqual("append_delta", "expected_append")
         self.assertTablesEqual("merge_no_key", "expected_append")
         self.assertTablesEqual("merge_unique_key", "expected_upsert")
+        self.assertTablesEqual("merge_update_columns", "expected_partial_upsert")
 
     @use_profile("databricks_cluster")
     def test_delta_strategies_databricks_cluster(self):


### PR DESCRIPTION
Resolves #183

~Cherry-pick onto `0.20.latest` after merging.~ It looks like we merged the version bump into `0.20.latest` but not into `master`. For simplicity, I'm going to rebase this PR onto `0.20.latest`. Then, after merging, let's merge the changes from `0.20.latest` into `master`—which, while we're at it, we may as well rename `main` or `develop`.

### Checklist
 - [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt next" section.
 